### PR TITLE
The first concept

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "colord",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "description": "👑 A tiny color manipulation and conversion tool",
   "keywords": [
     "color",
@@ -75,5 +75,6 @@
   },
   "prettier": {
     "printWidth": 100
-  }
+  },
+  "dependencies": {}
 }

--- a/src/colord.ts
+++ b/src/colord.ts
@@ -1,4 +1,4 @@
-import { Colord, Input, AnyColor } from "./types";
+import { Input, AnyColor, RgbaColor, HslaColor, HsvaColor } from "./types";
 import { parse } from "./parse";
 import { rgbaToHex } from "./convert/hex";
 import { rgbaToHexString } from "./convert/hexString";
@@ -9,25 +9,31 @@ import { rgbaToHsva } from "./convert/hsva";
 import { rgbaToHsvaString } from "./convert/hsvaString";
 import { saturate } from "./manipulate/saturate";
 
-export const colord = (input: AnyColor | Colord): Colord => {
-  // Internal color format is RGBA object
-  const parseResult = parse(input as Input);
-  const rgba = parseResult || { r: 0, g: 0, b: 0, a: 1 };
+export class Colord {
+  rgba: RgbaColor;
 
-  return {
-    isValid: () => parseResult !== null,
-    // Convert
-    toHex: () => rgbaToHex(rgba),
-    toHexString: () => rgbaToHexString(rgba),
-    toRgba: () => rgba,
-    toRgbaString: () => rgbaToRgbaString(rgba),
-    toHsla: () => rgbaToHsla(rgba),
-    toHslaString: () => rgbaToHslaString(rgba),
-    toHsva: () => rgbaToHsva(rgba),
-    toHsvaString: () => rgbaToHsvaString(rgba),
-    // Manipulate
-    saturate: (amount) => saturate(rgba, amount),
-    desaturate: (amount) => saturate(rgba, -amount),
-    grayscale: () => saturate(rgba, -100),
-  };
+  constructor(input: AnyColor) {
+    // Internal color format is RGBA object
+    this.rgba = parse(input as Input) || { r: 0, g: 0, b: 0, a: 1 };
+  }
+
+  // Convert
+  public toHex = (): string => rgbaToHex(this.rgba);
+  public toHexString = (): string => rgbaToHexString(this.rgba);
+  public toRgba = (): RgbaColor => this.rgba;
+  public toRgbaString = (): string => rgbaToRgbaString(this.rgba);
+  public toHsla = (): HslaColor => rgbaToHsla(this.rgba);
+  public toHslaString = (): string => rgbaToHslaString(this.rgba);
+  public toHsva = (): HsvaColor => rgbaToHsva(this.rgba);
+  public toHsvaString = (): string => rgbaToHsvaString(this.rgba);
+
+  // Manipulate
+  public saturate = (amount: number): Colord => saturate(this.rgba, amount);
+  public desaturate = (amount: number): Colord => saturate(this.rgba, -amount);
+  public grayscale = (): Colord => saturate(this.rgba, -100);
+}
+
+export const colord = (input: AnyColor | Colord): Colord => {
+  if (input instanceof Colord) return input;
+  return new Colord(input);
 };

--- a/src/colord.ts
+++ b/src/colord.ts
@@ -1,0 +1,33 @@
+import { Colord, Input, AnyColor } from "./types";
+import { parse } from "./parse";
+import { rgbaToHex } from "./convert/hex";
+import { rgbaToHexString } from "./convert/hexString";
+import { rgbaToRgbaString } from "./convert/rgbaString";
+import { rgbaToHsla } from "./convert/hsla";
+import { rgbaToHslaString } from "./convert/hslaString";
+import { rgbaToHsva } from "./convert/hsva";
+import { rgbaToHsvaString } from "./convert/hsvaString";
+import { saturate } from "./manipulate/saturate";
+
+export const colord = (input: AnyColor | Colord): Colord => {
+  // Internal color format is RGBA object
+  const parseResult = parse(input as Input);
+  const rgba = parseResult || { r: 0, g: 0, b: 0, a: 1 };
+
+  return {
+    isValid: () => parseResult !== null,
+    // Convert
+    toHex: () => rgbaToHex(rgba),
+    toHexString: () => rgbaToHexString(rgba),
+    toRgba: () => rgba,
+    toRgbaString: () => rgbaToRgbaString(rgba),
+    toHsla: () => rgbaToHsla(rgba),
+    toHslaString: () => rgbaToHslaString(rgba),
+    toHsva: () => rgbaToHsva(rgba),
+    toHsvaString: () => rgbaToHsvaString(rgba),
+    // Manipulate
+    saturate: (amount) => saturate(rgba, amount),
+    desaturate: (amount) => saturate(rgba, -amount),
+    grayscale: () => saturate(rgba, -100),
+  };
+};

--- a/src/convert/hex.ts
+++ b/src/convert/hex.ts
@@ -1,0 +1,10 @@
+import { RgbaColor } from "../types";
+
+const format = (number: number) => {
+  const hex = number.toString(16);
+  return hex.length < 2 ? "0" + hex : hex;
+};
+
+export const rgbaToHex = ({ r, g, b }: RgbaColor): string => {
+  return "#" + format(r) + format(g) + format(b);
+};

--- a/src/convert/hex.ts
+++ b/src/convert/hex.ts
@@ -6,5 +6,5 @@ const format = (number: number) => {
 };
 
 export const rgbaToHex = ({ r, g, b }: RgbaColor): string => {
-  return "#" + format(r) + format(g) + format(b);
+  return format(r) + format(g) + format(b);
 };

--- a/src/convert/hexString.ts
+++ b/src/convert/hexString.ts
@@ -1,0 +1,6 @@
+import { RgbaColor } from "../types";
+import { rgbaToHex } from "./hex";
+
+export const rgbaToHexString = (rgba: RgbaColor): string => {
+  return "#" + rgbaToHex(rgba);
+};

--- a/src/convert/hsla.ts
+++ b/src/convert/hsla.ts
@@ -1,5 +1,6 @@
+import { round } from "../helpers";
 import { RgbaColor, HslaColor, HsvaColor } from "../types";
-import { hsvaToRgba } from "./hsva";
+import { hsvaToRgba, rgbaToHsva } from "./hsva";
 
 export const hslaToHsva = ({ h, s, l, a }: HslaColor): HsvaColor => {
   s *= (l < 50 ? l : 100 - l) / 100;
@@ -12,6 +13,21 @@ export const hslaToHsva = ({ h, s, l, a }: HslaColor): HsvaColor => {
   };
 };
 
+export const hsvaToHsla = ({ h, s, v, a }: HsvaColor): HslaColor => {
+  const hh = ((200 - s) * v) / 100;
+
+  return {
+    h: round(h),
+    s: round(hh > 0 && hh < 200 ? ((s * v) / 100 / (hh <= 100 ? hh : 200 - hh)) * 100 : 0),
+    l: round(hh / 2),
+    a: round(a, 2),
+  };
+};
+
 export const hslaToRgba = (hsla: HslaColor): RgbaColor => {
   return hsvaToRgba(hslaToHsva(hsla));
+};
+
+export const rgbaToHsla = (rgba: RgbaColor): HslaColor => {
+  return hsvaToHsla(rgbaToHsva(rgba));
 };

--- a/src/convert/hsla.ts
+++ b/src/convert/hsla.ts
@@ -1,0 +1,17 @@
+import { RgbaColor, HslaColor, HsvaColor } from "../types";
+import { hsvaToRgba } from "./hsva";
+
+export const hslaToHsva = ({ h, s, l, a }: HslaColor): HsvaColor => {
+  s *= (l < 50 ? l : 100 - l) / 100;
+
+  return {
+    h: h,
+    s: s > 0 ? ((2 * s) / (l + s)) * 100 : 0,
+    v: l + s,
+    a,
+  };
+};
+
+export const hslaToRgba = (hsla: HslaColor): RgbaColor => {
+  return hsvaToRgba(hslaToHsva(hsla));
+};

--- a/src/convert/hslaString.ts
+++ b/src/convert/hslaString.ts
@@ -1,0 +1,7 @@
+import { RgbaColor } from "../types";
+import { rgbaToHsla } from "./hsla";
+
+export const rgbaToHslaString = (rgba: RgbaColor): string => {
+  const { h, s, l, a } = rgbaToHsla(rgba);
+  return `hsla(${h}, ${s}%, ${l}%, ${a})`;
+};

--- a/src/convert/hsva.ts
+++ b/src/convert/hsva.ts
@@ -1,6 +1,27 @@
 import { HsvaColor, RgbaColor } from "../types";
 import { round } from "../helpers";
 
+export const rgbaToHsva = ({ r, g, b, a }: RgbaColor): HsvaColor => {
+  const max = Math.max(r, g, b);
+  const delta = max - Math.min(r, g, b);
+
+  // prettier-ignore
+  const hh = delta
+    ? max === r
+      ? (g - b) / delta
+      : max === g
+        ? 2 + (b - r) / delta
+        : 4 + (r - g) / delta
+    : 0;
+
+  return {
+    h: round(60 * (hh < 0 ? hh + 6 : hh)),
+    s: round(max ? (delta / max) * 100 : 0),
+    v: round((max / 255) * 100),
+    a,
+  };
+};
+
 export const hsvaToRgba = ({ h, s, v, a }: HsvaColor): RgbaColor => {
   h = (h / 360) * 6;
   s = s / 100;

--- a/src/convert/hsva.ts
+++ b/src/convert/hsva.ts
@@ -1,0 +1,21 @@
+import { HsvaColor, RgbaColor } from "../types";
+import { round } from "../helpers";
+
+export const hsvaToRgba = ({ h, s, v, a }: HsvaColor): RgbaColor => {
+  h = (h / 360) * 6;
+  s = s / 100;
+  v = v / 100;
+
+  const hh = Math.floor(h),
+    b = v * (1 - s),
+    c = v * (1 - (h - hh) * s),
+    d = v * (1 - (1 - h + hh) * s),
+    module = hh % 6;
+
+  return {
+    r: round([v, c, b, b, d, v][module] * 255),
+    g: round([d, v, v, c, b, b][module] * 255),
+    b: round([b, b, d, v, v, c][module] * 255),
+    a: round(a, 2),
+  };
+};

--- a/src/convert/hsvaString.ts
+++ b/src/convert/hsvaString.ts
@@ -1,0 +1,7 @@
+import { RgbaColor } from "../types";
+import { rgbaToHsva } from "./hsva";
+
+export const rgbaToHsvaString = (rgba: RgbaColor): string => {
+  const { h, s, v, a } = rgbaToHsva(rgba);
+  return `hsva(${h}, ${s}%, ${v}%, ${a})`;
+};

--- a/src/convert/rgbaString.ts
+++ b/src/convert/rgbaString.ts
@@ -1,0 +1,5 @@
+import { RgbaColor } from "../types";
+
+export const rgbaToRgbaString = ({ r, g, b, a }: RgbaColor): string => {
+  return `rgba(${r}, ${g}, ${b}, ${a})`;
+};

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,0 +1,10 @@
+export const isPresent = (value: unknown): boolean => {
+  if (typeof value === "string") return value.length > 0;
+  if (typeof value === "number") return true;
+  if (typeof value === "boolean") return true;
+  return false;
+};
+
+export const round = (number: number, digits = 0, base = Math.pow(10, digits)): number => {
+  return Math.round(base * number) / base;
+};

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,10 +1,16 @@
 export const isPresent = (value: unknown): boolean => {
   if (typeof value === "string") return value.length > 0;
   if (typeof value === "number") return true;
-  if (typeof value === "boolean") return true;
   return false;
 };
 
 export const round = (number: number, digits = 0, base = Math.pow(10, digits)): number => {
   return Math.round(base * number) / base;
+};
+
+// Clamps a value between an upper and lower bound.
+// We use ternary operators because it makes the minified code
+// 2 times shorter then `Math.min(Math.max(a,b),c)`
+export const clamp = (number: number, min = 0, max = 1): number => {
+  return number > max ? max : number < min ? min : number;
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,18 @@
+import { Input, AnyColor } from "./types";
+import { parse } from "./parse";
+import { rgbaToHex } from "./convert/hex";
+
+interface Colord {
+  toHex: () => string;
+}
+
+const colord = (input: AnyColor): Colord => {
+  // Internal color format is RGBA object
+  const rgba = parse(input as Input) || { r: 0, g: 0, b: 0, a: 1 };
+
+  return {
+    toHex: () => rgbaToHex(rgba),
+  };
+};
+
+export default colord;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,18 +1,6 @@
-import { Input, AnyColor } from "./types";
-import { parse } from "./parse";
-import { rgbaToHex } from "./convert/hex";
-
-interface Colord {
-  toHex: () => string;
-}
-
-const colord = (input: AnyColor): Colord => {
-  // Internal color format is RGBA object
-  const rgba = parse(input as Input) || { r: 0, g: 0, b: 0, a: 1 };
-
-  return {
-    toHex: () => rgbaToHex(rgba),
-  };
-};
+import { colord } from "./colord";
 
 export default colord;
+
+export { Colord } from "./types";
+export { RgbColor, RgbaColor, HslColor, HslaColor, HsvColor, HsvaColor, AnyColor } from "./types";

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,2 @@
-import { colord } from "./colord";
-
-export default colord;
-
-export { Colord } from "./types";
+export { colord, Colord } from "./colord";
 export { RgbColor, RgbaColor, HslColor, HslaColor, HsvColor, HsvaColor, AnyColor } from "./types";

--- a/src/manipulate/saturate.ts
+++ b/src/manipulate/saturate.ts
@@ -1,7 +1,7 @@
 import { rgbaToHsla } from "../convert/hsla";
-import { Colord, RgbaColor } from "../types";
+import { RgbaColor } from "../types";
 import { clamp } from "../helpers";
-import { colord } from "../colord";
+import { colord, Colord } from "../colord";
 
 export const saturate = (rgba: RgbaColor, amount: number): Colord => {
   const { h, s, l, a } = rgbaToHsla(rgba);

--- a/src/manipulate/saturate.ts
+++ b/src/manipulate/saturate.ts
@@ -1,0 +1,15 @@
+import { rgbaToHsla } from "../convert/hsla";
+import { Colord, RgbaColor } from "../types";
+import { clamp } from "../helpers";
+import { colord } from "../colord";
+
+export const saturate = (rgba: RgbaColor, amount: number): Colord => {
+  const { h, s, l, a } = rgbaToHsla(rgba);
+
+  return colord({
+    h,
+    s: clamp(s + amount, 0, 100),
+    l,
+    a,
+  });
+};

--- a/src/parse/index.ts
+++ b/src/parse/index.ts
@@ -1,0 +1,9 @@
+import { Input, InputObject, RgbaColor } from "../types";
+import { parseObject } from "./parseObject";
+import { parseString } from "./parseString";
+
+export const parse = (input: Input): RgbaColor | null => {
+  if (typeof input === "string") return parseString(input);
+  if (typeof input === "object") return parseObject((input as unknown) as InputObject);
+  return null;
+};

--- a/src/parse/parseObject.ts
+++ b/src/parse/parseObject.ts
@@ -1,7 +1,14 @@
-import { InputObject, RgbaColor } from "../types";
+import { Colord, InputObject, RgbaColor } from "../types";
 import { isPresent } from "../helpers";
+import { hslaToRgba } from "../convert/hsla";
+import { hsvaToRgba } from "../convert/hsva";
 
-export const parseRgbaObject = ({ r, g, b, a = 1 }: InputObject): RgbaColor | null => {
+const parseColordObject = (object: InputObject): RgbaColor | null => {
+  if (typeof object.toRgba === "function") return ((object as unknown) as Colord).toRgba();
+  return null;
+};
+
+const parseRgbaObject = ({ r, g, b, a = 1 }: InputObject): RgbaColor | null => {
   if (!isPresent(r) || !isPresent(g) || !isPresent(b)) return null;
 
   return {
@@ -12,6 +19,30 @@ export const parseRgbaObject = ({ r, g, b, a = 1 }: InputObject): RgbaColor | nu
   };
 };
 
+const parseHslaObject = ({ h, s, l, a = 1 }: InputObject): RgbaColor | null => {
+  if (!isPresent(h) || !isPresent(s) || !isPresent(l)) return null;
+
+  return hslaToRgba({
+    h: Number(h),
+    s: Number(s),
+    l: Number(l),
+    a: Number(a),
+  });
+};
+
+const parseHsvaObject = ({ h, s, v, a = 1 }: InputObject): RgbaColor | null => {
+  if (!isPresent(h) || !isPresent(s) || !isPresent(v)) return null;
+
+  return hsvaToRgba({
+    h: Number(h),
+    s: Number(s),
+    v: Number(v),
+    a: Number(a),
+  });
+};
+
 export const parseObject = (o: InputObject): RgbaColor | null => {
-  return parseRgbaObject(o) || null;
+  return (
+    parseColordObject(o) || parseRgbaObject(o) || parseHslaObject(o) || parseHsvaObject(o) || null
+  );
 };

--- a/src/parse/parseObject.ts
+++ b/src/parse/parseObject.ts
@@ -1,12 +1,7 @@
-import { Colord, InputObject, RgbaColor } from "../types";
+import { InputObject, RgbaColor } from "../types";
 import { isPresent } from "../helpers";
 import { hslaToRgba } from "../convert/hsla";
 import { hsvaToRgba } from "../convert/hsva";
-
-const parseColordObject = (object: InputObject): RgbaColor | null => {
-  if (typeof object.toRgba === "function") return ((object as unknown) as Colord).toRgba();
-  return null;
-};
 
 const parseRgbaObject = ({ r, g, b, a = 1 }: InputObject): RgbaColor | null => {
   if (!isPresent(r) || !isPresent(g) || !isPresent(b)) return null;
@@ -42,7 +37,5 @@ const parseHsvaObject = ({ h, s, v, a = 1 }: InputObject): RgbaColor | null => {
 };
 
 export const parseObject = (o: InputObject): RgbaColor | null => {
-  return (
-    parseColordObject(o) || parseRgbaObject(o) || parseHslaObject(o) || parseHsvaObject(o) || null
-  );
+  return parseRgbaObject(o) || parseHslaObject(o) || parseHsvaObject(o) || null;
 };

--- a/src/parse/parseObject.ts
+++ b/src/parse/parseObject.ts
@@ -1,0 +1,17 @@
+import { InputObject, RgbaColor } from "../types";
+import { isPresent } from "../helpers";
+
+export const parseRgbaObject = ({ r, g, b, a = 1 }: InputObject): RgbaColor | null => {
+  if (!isPresent(r) || !isPresent(g) || !isPresent(b)) return null;
+
+  return {
+    r: Number(r),
+    g: Number(g),
+    b: Number(b),
+    a: Number(a),
+  };
+};
+
+export const parseObject = (o: InputObject): RgbaColor | null => {
+  return parseRgbaObject(o) || null;
+};

--- a/src/parse/parseString.ts
+++ b/src/parse/parseString.ts
@@ -1,0 +1,78 @@
+import { RgbaColor } from "../types";
+import { hslaToRgba } from "../convert/hsla";
+import { hsvaToRgba } from "../convert/hsva";
+
+const shorthandHexMatcher = /^#?[0-9A-F]{3}$/i;
+const regularHexMatcher = /^#?[0-9A-F]{6}$/i;
+const rgbaMatcher = /rgba?\((\d+),\s*(\d+),\s*(\d+),?\s*(\d+\.?\d*)?\)/;
+const hslaMatcher = /hsla?\((\d+\.?\d*),\s*(\d+\.?\d*)%?,\s*(\d+\.?\d*)%?,?\s*(\d+\.?\d*)?\)/;
+const hsvaMatcher = /hsva?\((\d+\.?\d*),\s*(\d+\.?\d*)%?,\s*(\d+\.?\d*)%?,?\s*(\d+\.?\d*)?\)/;
+
+const parseHex = (hex: string): RgbaColor | null => {
+  if (hex[0] === "#") hex = hex.substr(1);
+
+  if (shorthandHexMatcher.test(hex)) {
+    return {
+      r: parseInt(hex[0] + hex[0], 16),
+      g: parseInt(hex[1] + hex[1], 16),
+      b: parseInt(hex[2] + hex[2], 16),
+      a: 1,
+    };
+  }
+
+  if (regularHexMatcher.test(hex)) {
+    return {
+      r: parseInt(hex.substr(0, 2), 16),
+      g: parseInt(hex.substr(2, 2), 16),
+      b: parseInt(hex.substr(4, 2), 16),
+      a: 1,
+    };
+  }
+
+  return null;
+};
+
+const parseRgbaString = (input: string): RgbaColor | null => {
+  const match = rgbaMatcher.exec(input);
+
+  return (
+    match && {
+      r: Number(match[1]),
+      g: Number(match[2]),
+      b: Number(match[3]),
+      a: match[4] === undefined ? 1 : Number(match[4]),
+    }
+  );
+};
+
+const parseHslaString = (input: string): RgbaColor | null => {
+  const match = hslaMatcher.exec(input);
+
+  return (
+    match &&
+    hslaToRgba({
+      h: Number(match[1]),
+      s: Number(match[2]),
+      l: Number(match[3]),
+      a: match[4] === undefined ? 1 : Number(match[4]),
+    })
+  );
+};
+
+const parseHsvaString = (input: string): RgbaColor | null => {
+  const match = hsvaMatcher.exec(input);
+
+  return (
+    match &&
+    hsvaToRgba({
+      h: Number(match[1]),
+      s: Number(match[2]),
+      v: Number(match[3]),
+      a: match[4] === undefined ? 1 : Number(match[4]),
+    })
+  );
+};
+
+export const parseString = (s: string): RgbaColor | null => {
+  return parseHex(s) || parseRgbaString(s) || parseHslaString(s) || parseHsvaString(s) || null;
+};

--- a/src/types.ts
+++ b/src/types.ts
@@ -37,20 +37,3 @@ export interface InputObject {
 }
 
 export type Input = string | InputObject;
-
-export interface Colord {
-  isValid: () => boolean;
-  // Convert
-  toHex: () => string;
-  toHexString: () => string;
-  toRgba: () => RgbaColor;
-  toRgbaString: () => string;
-  toHsla: () => HslaColor;
-  toHslaString: () => string;
-  toHsva: () => HsvaColor;
-  toHsvaString: () => string;
-  // Manipulate
-  saturate: (amount: number) => Colord;
-  desaturate: (amount: number) => Colord;
-  grayscale: () => Colord;
-}

--- a/src/types.ts
+++ b/src/types.ts
@@ -37,3 +37,20 @@ export interface InputObject {
 }
 
 export type Input = string | InputObject;
+
+export interface Colord {
+  isValid: () => boolean;
+  // Convert
+  toHex: () => string;
+  toHexString: () => string;
+  toRgba: () => RgbaColor;
+  toRgbaString: () => string;
+  toHsla: () => HslaColor;
+  toHslaString: () => string;
+  toHsva: () => HsvaColor;
+  toHsvaString: () => string;
+  // Manipulate
+  saturate: (amount: number) => Colord;
+  desaturate: (amount: number) => Colord;
+  grayscale: () => Colord;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,39 @@
+export interface RgbColor {
+  r: number;
+  g: number;
+  b: number;
+}
+
+export interface RgbaColor extends RgbColor {
+  a: number;
+}
+
+export interface HslColor {
+  h: number;
+  s: number;
+  l: number;
+}
+
+export interface HslaColor extends HslColor {
+  a: number;
+}
+
+export interface HsvColor {
+  h: number;
+  s: number;
+  v: number;
+}
+
+export interface HsvaColor extends HsvColor {
+  a: number;
+}
+
+export type ObjectColor = RgbColor | HslColor | HsvColor | RgbaColor | HslaColor | HsvaColor;
+
+export type AnyColor = string | ObjectColor;
+
+export interface InputObject {
+  [key: string]: unknown;
+}
+
+export type Input = string | InputObject;

--- a/tests/colord.test.ts
+++ b/tests/colord.test.ts
@@ -1,0 +1,8 @@
+import colord from "../src/";
+
+it("Parses string and converts it to HEX", () => {
+  expect(colord("#FFF").toHex()).toBe("#ffffff");
+  expect(colord("rgba(50, 100, 200)").toHex()).toBe("#3264c8");
+  expect(colord("hsl(20, 40%, 60%)").toHex()).toBe("#c28b70");
+  expect(colord("hsv(50, 100%, 100%)").toHex()).toBe("#ffd500");
+});

--- a/tests/colord.test.ts
+++ b/tests/colord.test.ts
@@ -1,8 +1,43 @@
-import colord from "../src/";
+import colord, { AnyColor } from "../src/";
+import { HslaColor, RgbaColor } from "../src/types";
+import { lime } from "./fixtures";
 
-it("Parses string and converts it to HEX", () => {
-  expect(colord("#FFF").toHex()).toBe("#ffffff");
-  expect(colord("rgba(50, 100, 200)").toHex()).toBe("#3264c8");
-  expect(colord("hsl(20, 40%, 60%)").toHex()).toBe("#c28b70");
-  expect(colord("hsv(50, 100%, 100%)").toHex()).toBe("#ffd500");
+it("Parses and converts a color", () => {
+  for (const format in lime) {
+    const instance = colord(lime[format] as AnyColor);
+    expect(instance.toHex()).toBe(lime.hex);
+    expect(instance.toHexString()).toBe(lime.hexString);
+    expect(instance.toRgba()).toMatchObject(lime.rgba);
+    expect(instance.toRgbaString()).toBe(lime.rgbaString);
+    expect(instance.toHsla()).toMatchObject(lime.hsla);
+    expect(instance.toHslaString()).toBe(lime.hslaString);
+    expect(instance.toHsva()).toMatchObject(lime.hsva);
+    expect(instance.toHsvaString()).toBe(lime.hsvaString);
+    expect(instance.isValid()).toBe(true);
+  }
+});
+
+it("Validates a color", () => {
+  expect(colord("#FFF").isValid()).toBe(true);
+  expect(colord({ r: 255, g: 255, b: 255 }).isValid()).toBe(true);
+  expect(colord({ h: 360, s: 100, l: 100 }).isValid()).toBe(true);
+  expect(colord({ h: 360, s: 100, v: 100, a: 1 }).isValid()).toBe(true);
+  expect(colord((undefined as unknown) as AnyColor).isValid()).toBe(false);
+  expect(colord("").isValid()).toBe(false);
+  expect(colord("#0").isValid()).toBe(false);
+  expect(colord("#FF").isValid()).toBe(false);
+  expect(colord({} as RgbaColor).isValid()).toBe(false);
+  expect(colord({ r: 255, g: 255 } as RgbaColor).isValid()).toBe(false);
+  expect(colord({ h: 255, s: 255 } as HslaColor).isValid()).toBe(false);
+});
+
+it("Accepts a colord instance as an input", () => {
+  const instance = colord(lime.hex as string);
+  expect(colord(instance).toRgba()).toMatchObject(lime.rgba);
+  expect(colord(colord(instance)).toHsla()).toMatchObject(lime.hsla);
+});
+
+it("Makes a color grayscale", () => {
+  expect(colord("#F00").grayscale().toHexString()).toBe("#808080");
+  expect(colord(colord("#F00").grayscale()).toHexString()).toBe("#808080");
 });

--- a/tests/colord.test.ts
+++ b/tests/colord.test.ts
@@ -1,5 +1,4 @@
-import colord, { AnyColor } from "../src/";
-import { HslaColor, RgbaColor } from "../src/types";
+import { colord, AnyColor } from "../src/";
 import { lime } from "./fixtures";
 
 it("Parses and converts a color", () => {
@@ -13,22 +12,7 @@ it("Parses and converts a color", () => {
     expect(instance.toHslaString()).toBe(lime.hslaString);
     expect(instance.toHsva()).toMatchObject(lime.hsva);
     expect(instance.toHsvaString()).toBe(lime.hsvaString);
-    expect(instance.isValid()).toBe(true);
   }
-});
-
-it("Validates a color", () => {
-  expect(colord("#FFF").isValid()).toBe(true);
-  expect(colord({ r: 255, g: 255, b: 255 }).isValid()).toBe(true);
-  expect(colord({ h: 360, s: 100, l: 100 }).isValid()).toBe(true);
-  expect(colord({ h: 360, s: 100, v: 100, a: 1 }).isValid()).toBe(true);
-  expect(colord((undefined as unknown) as AnyColor).isValid()).toBe(false);
-  expect(colord("").isValid()).toBe(false);
-  expect(colord("#0").isValid()).toBe(false);
-  expect(colord("#FF").isValid()).toBe(false);
-  expect(colord({} as RgbaColor).isValid()).toBe(false);
-  expect(colord({ r: 255, g: 255 } as RgbaColor).isValid()).toBe(false);
-  expect(colord({ h: 255, s: 255 } as HslaColor).isValid()).toBe(false);
 });
 
 it("Accepts a colord instance as an input", () => {

--- a/tests/fixtures.ts
+++ b/tests/fixtures.ts
@@ -1,0 +1,26 @@
+import { Input } from "../src/types";
+
+interface TestColor {
+  [key: string]: Input;
+}
+
+export const lime: TestColor = {
+  shorthandHex: "0F0",
+  hex: "00ff00",
+  hexString: "#00ff00",
+  rgb: { r: 0, g: 255, b: 0 },
+  rgbString: "rgb(0, 255, 0)",
+  rgbStringNoSpaces: "rgb(0,255,0)",
+  rgba: { r: 0, g: 255, b: 0, a: 1 },
+  rgbaString: "rgba(0, 255, 0, 1)",
+  hsl: { h: 120, s: 100, l: 50 },
+  hslString: "hsl(120, 100%, 50%)",
+  hslStringNoSpacesAndPercent: "hsl(120,100,50)",
+  hsla: { h: 120, s: 100, l: 50, a: 1 },
+  hslaString: "hsla(120, 100%, 50%, 1)",
+  hsv: { h: 120, s: 100, v: 100 },
+  hsvString: "hsv(120, 100%, 100%)",
+  hsvStringNoSpacesAndPercent: "hsv(120,100,100)",
+  hsva: { h: 120, s: 100, v: 100, a: 1 },
+  hsvaString: "hsva(120, 100%, 100%, 1)",
+};


### PR DESCRIPTION
It's been a long time, @molefrog @rschristian! 

I decided to use our experience from `react-colorful` to create a new color conversion and manipulation tool.
It's called `colord` (🎨Color + 👑Lord).

Actually, the color tool market is quite crowded already, but several packages have most of the market:
https://www.npmjs.com/package/color-convert (37M downloads weekly) — 13 KB, has 1 dependency
https://www.npmjs.com/package/color (11M downloads weekly) — 22.4 KB, has 2 dependencies
https://www.npmjs.com/package/tinycolor2 (3M downloads weekly) — 14,4 KB

The idea is to create a tool that will support most of their features but will be better, lighter, faster, and TS-oriented.

This PR is the first concept that I would like to share with you to hear your thoughts.

The API is going to be similar to tinycolor2's one and the library won't be tree-shakeable (like all popular color conversion tools).
```js
import colord from 'colord'
colord("#F00").grayscale().toRgbaString() // "rgba(128, 128, 128, 1)"

```
Tinycolor2 is not the most popular color tool, but I like their API. It's pretty simple to understand.

Why I'm not going to create a tree-shakeable library? Because nobody likes them.
Example: I know 2 tree-shakeable color conversion tools:
https://www.npmjs.com/package/color-fns
https://www.npmjs.com/package/@swiftcarrot/color-fns
Just 2k downloads weekly just because nobody wants to dig into color models and do extra work. Only geeks like me can use libraries of this kind =)
```js
rgbaToHex(grayscale(parseRgba(rgba))) // the code nobody wants to write
magick(rgba).grayscale().toHex() // the cope people like
```

So I think our way is to copy the API of the popular libraries (it means to be not tree-shakeable), but make the library faster/lighter, and provide better DX.

Current bundle size: 3KB min, 1.14 KB gzip.

Any feedback is welcome ❤️