### PR TITLE
Make the library 100% ESM

### DIFF
--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -23,3 +23,6 @@ jobs:
       - run: npm run check-types
       - run: npm run test
       - run: npm run size
+
+      - name: Code coverage report
+        uses: codecov/codecov-action@v1

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "lint": "eslint src/**/*.ts",
     "size": "npm run build && size-limit",
     "check-types": "tsc --noEmit true",
-    "test": "jest tests",
+    "test": "jest tests --coverage",
     "build": "rm -rf ./dist/* && rollup --config",
     "prepublishOnly": "npm run build"
   },

--- a/package.json
+++ b/package.json
@@ -15,46 +15,44 @@
   "repository": "omgovich/colord",
   "author": "Vlad Shilov <omgovich@ya.ru>",
   "license": "MIT",
-  "source": "src/index.ts",
-  "main": "dist/index.js",
-  "module": "dist/index.module.js",
-  "esmodule": "dist/index.esmodule.js",
-  "umd:main": "dist/index.umd.js",
-  "types": "dist/index.d.ts",
+  "type": "module",
+  "engines": {
+    "node": ">=12"
+  },
   "exports": {
-    ".": {
-      "browser": "./dist/index.module.js",
-      "umd": "./dist/index.umd.js",
-      "import": "./dist/index.module.js",
-      "require": "./dist/index.js"
-    }
+    ".": "./dist/index.js"
   },
   "files": [
-    "dist"
+    "dist/*.{js,ts,map}"
   ],
+  "types": "dist/index.d.ts",
+  "source": "src/index.ts",
   "scripts": {
     "lint": "eslint src/**/*.ts",
     "size": "npm run build && size-limit",
     "check-types": "tsc --noEmit true",
     "test": "jest tests",
-    "build": "rm -rf ./dist/* && microbundle build --name colord",
+    "build": "rm -rf ./dist/* && rollup --config",
     "prepublishOnly": "npm run build"
   },
   "dependencies": {},
   "devDependencies": {
-    "@size-limit/preset-small-lib": "^4.9.0",
-    "@types/jest": "^26.0.15",
-    "@typescript-eslint/eslint-plugin": "^4.8.2",
-    "@typescript-eslint/parser": "^4.8.2",
+    "@size-limit/preset-small-lib": "^4.10.1",
+    "@types/jest": "^26.0.22",
+    "@typescript-eslint/eslint-plugin": "^4.19.0",
+    "@typescript-eslint/parser": "^4.19.0",
     "eslint": "^7.14.0",
     "eslint-config-prettier": "^6.15.0",
     "eslint-plugin-prettier": "^3.1.4",
     "jest": "^26.6.3",
-    "microbundle": "^0.12.4",
     "prettier": "^2.2.0",
-    "size-limit": "^4.9.0",
-    "ts-jest": "^26.4.4",
-    "typescript": "^4.1.2"
+    "rollup": "^2.43.1",
+    "rollup-plugin-terser": "^7.0.2",
+    "rollup-plugin-typescript2": "^0.30.0",
+    "size-limit": "^4.10.1",
+    "ts-jest": "^26.5.4",
+    "tslib": "^2.1.0",
+    "typescript": "^4.2.3"
   },
   "jest": {
     "verbose": true,
@@ -79,8 +77,8 @@
   },
   "size-limit": [
     {
-      "path": "dist/index.module.js",
-      "limit": "3 KB"
+      "path": "dist/index.js",
+      "limit": "2 KB"
     }
   ]
 }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,0 +1,20 @@
+import typescript from "rollup-plugin-typescript2";
+import { terser } from "rollup-plugin-terser";
+
+export default {
+  input: "src/index.ts",
+  output: {
+    file: "dist/index.js",
+    format: "es",
+  },
+  plugins: [
+    typescript(),
+    terser({
+      ecma: 5,
+      module: true,
+      toplevel: true,
+      compress: { pure_getters: true },
+      format: { wrap_func_args: false },
+    }),
+  ],
+};

--- a/src/types.ts
+++ b/src/types.ts
@@ -32,9 +32,7 @@ export type ObjectColor = RgbColor | HslColor | HsvColor | RgbaColor | HslaColor
 
 export type AnyColor = string | ObjectColor;
 
-export interface InputObject {
-  [key: string]: unknown;
-}
+export type InputObject = Record<string, unknown>;
 
 export type Input = string | InputObject;
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,10 +1,12 @@
 {
   "compilerOptions": {
-    "target": "ESNext",
+    "target": "ES5",
     "module": "ESNext",
     "esModuleInterop": true,
     "moduleResolution": "node",
     "declaration": true,
-    "strict": true
-  }
+    "strict": true,
+    "outDir": "dist"
+  },
+  "include": ["./src/**/*", "./test/**/*"]
 }


### PR DESCRIPTION
Drop CJS support since Node 10 is no longer LTS and Node 12 supports ESM out of the box.