### PR TITLE
Plugin: Support XYZ color space objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ colord("#aabbcc").toName(); // undefined (the color is not specified in CSS spec
 
 ### XYZ color space
 
-Adds supports of [CIE XYZ](https://www.sttmedia.com/colormodel-xyz) color space. The color conversion logic is ported from [CSS Color Module Level 4 Specification](https://www.w3.org/TR/css-color-4/#color-conversion-code).
+Adds support of [CIE XYZ](https://www.sttmedia.com/colormodel-xyz) color model. The conversion logic is ported from [CSS Color Module Level 4 Specification](https://www.w3.org/TR/css-color-4/#color-conversion-code).
 
 ```js
 import { colord, extend } from "colord";

--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ colord("hsl(0, 50%, 50%)").darken(0.25).toHex(); // "#602020"
 - HSL(A) strings and objects
 - HSV(A) objects
 - Color names ([via plugin](#css-color-names))
+- XYZ objects ([via plugin](#xyz-color-space))
 - LCH (coming soon)
 
 ```js
@@ -165,6 +166,20 @@ colord("#00ffff").toName(); // "cyan"
 colord("#aabbcc").toName(); // undefined (the color is not specified in CSS specs)
 ```
 
+### XYZ color space
+
+Adds supports of [CIE XYZ](https://www.sttmedia.com/colormodel-xyz) color space. The color conversion logic is ported from [CSS Color Module Level 4 Specification](https://www.w3.org/TR/css-color-4/#color-conversion-code).
+
+```js
+import { colord, extend } from "colord";
+import xyzPlugin from "colord/plugins/xyz";
+
+extend([xyzPlugin]);
+
+colord("#ffffff").toXyz(); // { x: 95.047, y: 100, z: 108.883, a: 1 }
+colord({ x: 0, y: 0, z: 0 }).toHex(); // "#000000"
+```
+
 <div><img src="assets/divider.png" width="838" alt="---" /></div>
 
 ## Types
@@ -193,9 +208,9 @@ const bar: RgbColor = { r: 0, g: 0, v: 0 }; // ERROR
 - [x] `lighten`, `darken`
 - [x] `invert`
 - [x] CSS color names (via plugin)
-- [ ] 🚧 Mix colors (via plugin)
+- [ ] Mix colors (via plugin)
 - [ ] A11y and contrast utils (via plugin)
 - [ ] CMYK color space (via plugin)
-- [ ] XYZ color space (via plugin)
+- [ ] 🚧 XYZ color space (via plugin)
 - [ ] [LAB](https://www.w3.org/TR/css-color-4/#resolving-lab-lch-values) color space (via plugin)
 - [ ] [LCH](https://lea.verou.me/2020/04/lch-colors-in-css-what-why-and-how/) color space (via plugin)

--- a/package.json
+++ b/package.json
@@ -108,6 +108,10 @@
     {
       "path": "dist/plugins/names.js",
       "limit": "1.5 KB"
+    },
+    {
+      "path": "dist/plugins/xyz.js",
+      "limit": "1 KB"
     }
   ]
 }

--- a/src/colorModels/xyz.ts
+++ b/src/colorModels/xyz.ts
@@ -1,0 +1,84 @@
+import { InputObject, RgbaColor, XyzaColor } from "../types";
+import { clamp, isPresent, round } from "../helpers";
+import { clampRgba } from "./rgba";
+
+/**
+ * Limits XYZ axis values
+ * https://www.sttmedia.com/colormodel-xyz
+ */
+export const clampXyza = ({ x, y, z, a }: XyzaColor): XyzaColor => ({
+  x: clamp(x, 0, 95.047),
+  y: clamp(y, 0, 100),
+  z: clamp(z, 0, 108.883),
+  a: clamp(a),
+});
+
+export const roundXyza = ({ x, y, z, a }: XyzaColor): XyzaColor => ({
+  x: round(x, 3),
+  y: round(y, 3),
+  z: round(z, 3),
+  a: round(a, 2),
+});
+
+export const parseXyza = ({ x, y, z, a = 1 }: InputObject): RgbaColor | null => {
+  if (!isPresent(x) || !isPresent(y) || !isPresent(z)) return null;
+
+  const xyza = clampXyza({
+    x: Number(x),
+    y: Number(y),
+    z: Number(z),
+    a: Number(a),
+  });
+
+  return xyzaToRgba(xyza);
+};
+
+/**
+ * Converts an RGB channel [0-255] to its linear light (un-companded) form [0-1].
+ */
+const linearizeRgbChannel = (value: number): number => {
+  const ratio = value / 255;
+  return ratio < 0.04045 ? ratio / 12.92 : Math.pow((ratio + 0.055) / 1.055, 2.4);
+};
+
+/**
+ * Convert an linear-light sRGB channel [0-1] to its gamma corrected form [0-255].
+ */
+const unlinearizeRgbChannel = (ratio: number): number => {
+  const value = ratio > 0.0031308 ? 1.055 * Math.pow(ratio, 1 / 2.4) - 0.055 : 12.92 * ratio;
+  return value * 255;
+};
+
+/**
+ * Converts an CIE XYZ color to RGBA color space
+ * https://www.w3.org/TR/css-color-4/#color-conversion-code
+ */
+export const xyzaToRgba = (xyza: XyzaColor): RgbaColor => {
+  const x = xyza.x / 100;
+  const y = xyza.y / 100;
+  const z = xyza.z / 100;
+
+  return clampRgba({
+    r: unlinearizeRgbChannel(3.2404542 * x - 1.5371385 * y - 0.4985314 * z),
+    g: unlinearizeRgbChannel(-0.969266 * x + 1.8760108 * y + 0.041556 * z),
+    b: unlinearizeRgbChannel(0.0556434 * x - 0.2040259 * y + 1.0572252 * z),
+    a: xyza.a,
+  });
+};
+
+/**
+ * Converts an RGBA color to CIE XYZ
+ * https://image-engineering.de/library/technotes/958-how-to-convert-between-srgb-and-ciexyz
+ */
+export const rgbaToXyza = ({ r, g, b, a }: RgbaColor): XyzaColor => {
+  const sRed = linearizeRgbChannel(r);
+  const sGreen = linearizeRgbChannel(g);
+  const sBlue = linearizeRgbChannel(b);
+
+  return clampXyza({
+    x: (sRed * 0.4124564 + sGreen * 0.3575761 + sBlue * 0.1804375) * 100,
+    y: (sRed * 0.2126729 + sGreen * 0.7151522 + sBlue * 0.072175) * 100,
+    z: (sRed * 0.0193339 + sGreen * 0.119192 + sBlue * 0.9503041) * 100,
+    a,
+  });
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,14 @@
 export { colord, Colord } from "./colord";
-export { RgbColor, RgbaColor, HslColor, HslaColor, HsvColor, HsvaColor, AnyColor } from "./types";
 export { extend, Plugin } from "./extend";
+
+export {
+  RgbColor,
+  RgbaColor,
+  HslColor,
+  HslaColor,
+  HsvColor,
+  HsvaColor,
+  XyzColor,
+  XyzaColor,
+  AnyColor,
+} from "./types";

--- a/src/plugins/xyz.ts
+++ b/src/plugins/xyz.ts
@@ -1,0 +1,24 @@
+import { XyzaColor } from "../types";
+import { Plugin } from "../extend";
+import { parseXyza, rgbaToXyza, roundXyza } from "../colorModels/xyz";
+
+declare module "../colord" {
+  interface Colord {
+    toXyz(): XyzaColor;
+  }
+}
+
+/**
+ * A plugin adding support for CIE XYZ colorspace.
+ * Wikipedia: https://en.wikipedia.org/wiki/CIE_1931_color_space
+ * Helpful article: https://www.sttmedia.com/colormodel-xyz
+ */
+const xyzPlugin: Plugin = (ColordClass, parsers): void => {
+  ColordClass.prototype.toXyz = function () {
+    return roundXyza(rgbaToXyza(this.rgba));
+  };
+
+  parsers.object.push(parseXyza);
+};
+
+export default xyzPlugin;

--- a/src/types.ts
+++ b/src/types.ts
@@ -28,7 +28,27 @@ export interface HsvaColor extends HsvColor {
   a: number;
 }
 
-export type ObjectColor = RgbColor | HslColor | HsvColor | RgbaColor | HslaColor | HsvaColor;
+/** CIE XYZ color space https://www.sttmedia.com/colormodel-xyz */
+export interface XyzColor {
+  x: number;
+  y: number;
+  z: number;
+}
+
+/** CIE XYZ with and an alpha channel. Naming is the hardest part: https://stackoverflow.com/a/2464027 */
+export interface XyzaColor extends XyzColor {
+  a: number;
+}
+
+export type ObjectColor =
+  | RgbColor
+  | RgbaColor
+  | HslColor
+  | HslaColor
+  | HsvColor
+  | HsvaColor
+  | XyzColor
+  | XyzaColor;
 
 export type AnyColor = string | ObjectColor;
 

--- a/tests/plugins.test.ts
+++ b/tests/plugins.test.ts
@@ -1,5 +1,6 @@
 import { colord, extend } from "../src/";
 import namesPlugin from "../src/plugins/names";
+import xyzPlugin from "../src/plugins/xyz";
 
 describe("names", () => {
   extend([namesPlugin]);
@@ -17,5 +18,23 @@ describe("names", () => {
   it("Does not crash when name is not found", () => {
     expect(colord("#123456").toName()).toBe(undefined);
     expect(colord("myownpurple").toHex()).toBe("#000000");
+  });
+});
+
+describe("xyz", () => {
+  extend([xyzPlugin]);
+
+  it("Parses XYZ color object", () => {
+    // https://www.nixsensor.com/free-color-converter/
+    expect(colord({ x: 0, y: 0, z: 0 }).toHex()).toBe("#000000");
+    expect(colord({ x: 50, y: 50, z: 50 }).toHex()).toBe("#ccb7b4");
+    expect(colord({ x: 95.047, y: 100, z: 108.883, a: 1 }).toHex()).toBe("#ffffff");
+  });
+
+  it("Converts a color to CIE XYZ name", () => {
+    // https://www.easyrgb.com/en/convert.php
+    expect(colord("#ffffff").toXyz()).toMatchObject({ x: 95.047, y: 100, z: 108.883, a: 1 });
+    expect(colord("#5cbf54").toXyz()).toMatchObject({ x: 24.643, y: 40.175, z: 14.842, a: 1 });
+    expect(colord("#00000000").toXyz()).toMatchObject({ x: 0, y: 0, z: 0, a: 0 });
   });
 });


### PR DESCRIPTION
We need to support XYZ color space in order to provide plugins for a11y utils and LCH color model support. 