### PR TITLE
New plugin: A11y

### DIFF
--- a/README.md
+++ b/README.md
@@ -373,10 +373,7 @@ colord("#ffffff").luminance(); // 1
 <details>
   <summary><b><code>contrast(color2 = "#FFF")</code></b> (<b>a11y</b> plugin)</summary>
 
-Calculates a contrast ratio for a color pair. This luminance difference is expressed as a ratio ranging from 1 (e.g. white on white) to 21 (e.g., black on a white). WCAG requires a ratio of at least 4.5 for normal text and 3 for large text.
-
-- [Understanding WCAG 2 Contrast and Color Requirements](https://webaim.org/articles/contrast/)
-- [Contrast Checker](https://webaim.org/resources/contrastchecker/)
+Calculates a contrast ratio for a color pair. This luminance difference is expressed as a ratio ranging from 1 (e.g. white on white) to 21 (e.g., black on a white). [WCAG Accessibility Level AA requires](https://webaim.org/articles/contrast/) a ratio of at least 4.5 for normal text and 3 for large text.
 
 ```js
 colord("#000000").contrast(); // 21 (black on white)
@@ -389,19 +386,17 @@ colord("#0000ff").contrast("#ff000"); // 2.14 (blue on red)
 </details>
 
 <details>
-  <summary><b><code>isReadable(color2 = "#FFF", level = "AA")</code></b> (<b>a11y</b> plugin)</summary>
+  <summary><b><code>isReadable(color2 = "#FFF", options?)</code></b> (<b>a11y</b> plugin)</summary>
 
-Checks a contrast between background and text colors. [WCAG 2.0 contrast ratio requirements](https://www.w3.org/TR/UNDERSTANDING-WCAG20/visual-audio-contrast-contrast.html) for a normal text:
-
-- Level AA — at least 4.5
-- Level AAA — at least 7
+Checks that a background and text color pair is readable according to [WCAG 2.0 Contrast and Color Requirements](https://webaim.org/articles/contrast/).
 
 ```js
-colord("#000000").isReadable(); // true (black on white)
-colord("#ffffff").isReadable("#000000"); // true (white on black)
-colord("#777777").isReadable(); // false (gray on white)
-colord("#e60000").isReadable("#ffff47"); // true (red on yellow conforms WCAG AA)
-colord("#e60000").isReadable("#ffff47", "AAA"); // false (red on yellow does not conform WCAG AAA)
+colord("#000000").isReadable(); // true (normal black text on white bg conforms to WCAG AA)
+colord("#777777").isReadable(); // false (normal gray text on white bg conforms to WCAG AA)
+colord("#ffffff").isReadable("#000000"); // true (normal white text on black bg conforms to WCAG AA)
+colord("#e60000").isReadable("#ffff47"); // true (normal red text on yellow bg conforms to WCAG AA)
+colord("#e60000").isReadable("#ffff47", { level: "AAA" }); // false (normal red text on yellow bg does not conform to WCAG AAA)
+colord("#e60000").isReadable("#ffff47", { level: "AAA", size: "large" }); // true (large red text on yellow bg conforms to WCAG AAA)
 ```
 
 </details>
@@ -413,7 +408,7 @@ colord("#e60000").isReadable("#ffff47", "AAA"); // false (red on yellow does not
 **Colord** has a built-in plugin system that allows new features and functionality to be easily added.
 
 <details>
-  <summary><b>Accessibility (a11y)</b></summary>
+  <summary><b><code>a11y</code> (Accessibility)</b></summary>
 
 Adds accessibility and color contrast utilities working according to [Web Content Accessibility Guidelines 2.0](https://www.w3.org/TR/WCAG20/).
 
@@ -441,7 +436,7 @@ colord("#e60000").isReadable("#ffff47", "AAA"); // false (red on yellow does not
 </details>
 
 <details>
-  <summary><b>CSS color names</b></summary>
+  <summary><b><code>names</code> (CSS color keywords)</b></summary>
 
 Provides options to convert a color into a [CSS color keyword](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value#color_keywords) and vice versa.
 
@@ -459,7 +454,7 @@ colord("#aabbcc").toName(); // undefined (the color is not specified in CSS spec
 </details>
 
 <details>
-  <summary><b>XYZ color space</b></summary>
+  <summary><b><code>xyz</code> (CIE XYZ color space)</b></summary>
 
 Adds support of [CIE XYZ](https://www.sttmedia.com/colormodel-xyz) color model. The conversion logic is ported from [CSS Color Module Level 4 Specification](https://www.w3.org/TR/css-color-4/#color-conversion-code).
 

--- a/README.md
+++ b/README.md
@@ -356,11 +356,89 @@ colord("#ffffff").isDark(); // false
 
 </details>
 
+<details>
+  <summary><b><code>luminance()</code></b> (<b>a11y</b> plugin)</summary>
+
+Returns the relative luminance of a color, normalized to 0 for darkest black and 1 for lightest white as defined by [WCAG 2.0](https://www.w3.org/TR/WCAG20/#relativeluminancedef).
+
+```js
+colord("#000000").luminance(); // 0
+colord("#808080").luminance(); // 0.22
+colord("#ccddee").luminance(); // 0.71
+colord("#ffffff").luminance(); // 1
+```
+
+</details>
+
+<details>
+  <summary><b><code>contrast(color2 = '#ffffff')</code></b> (<b>a11y</b> plugin)</summary>
+
+Calculates a contrast ratio for a color pair. This luminance difference is expressed as a ratio ranging from 1 (e.g. white on white) to 21 (e.g., black on a white). WCAG requires a ratio of at least 4.5 for normal text and 3 for large text.
+
+- [Understanding WCAG 2 Contrast and Color Requirements](https://webaim.org/articles/contrast/)
+- [Contrast Checker](https://webaim.org/resources/contrastchecker/)
+
+```js
+colord("#000000").contrast(); // 21 (black on white)
+colord("#ffffff").contrast("#000000"); // 21 (white on black)
+colord("#777777").contrast(); // 4.47 (gray on white)
+colord("#ff0000").contrast(); // 3.99 (red on white)
+colord("#0000ff").contrast("#ff000"); // 2.14 (blue on red)
+```
+
+</details>
+
+<details>
+  <summary><b><code>isReadable(color2 = '#ffffff', level = 'AA')</code></b> (<b>a11y</b> plugin)</summary>
+
+Checks a contrast between background and text colors. [WCAG 2.0 contrast ratio requirements](https://www.w3.org/TR/UNDERSTANDING-WCAG20/visual-audio-contrast-contrast.html) for a normal text:
+
+- Level AA — at least 4.5
+- Level AAA — at least 7
+
+```js
+colord("#000000").isReadable(); // true (black on white)
+colord("#ffffff").isReadable("#000000"); // true (white on black)
+colord("#777777").isReadable(); // false (gray on white)
+colord("#e60000").isReadable("#ffff47"); // true (red on yellow conforms WCAG AA)
+colord("#e60000").isReadable("#ffff47", "AAA"); // false (red on yellow does not conform WCAG AAA)
+```
+
+</details>
+
 <div><img src="assets/divider.png" width="838" alt="---" /></div>
 
 ## Plugins
 
 **Colord** has a built-in plugin system that allows new features and functionality to be easily added.
+
+<details>
+  <summary><b>Accessibility (A11y)</b></summary>
+
+Adds accessibility and color contrast utilities working according to [Web Content Accessibility Guidelines 2.0](https://www.w3.org/TR/WCAG20/).
+
+```js
+import { colord, extend } from "colord";
+import a11yPlugin from "colord/plugins/a11y";
+
+extend([a11yPlugin]);
+
+colord("#000000").luminance(); // 0
+colord("#ccddee").luminance(); // 0.71
+colord("#ffffff").luminance(); // 1
+
+colord("#000000").contrast(); // 21 (black on white)
+colord("#ffffff").contrast("#000000"); // 21 (white on black)
+colord("#0000ff").contrast("#ff000"); // 2.14 (blue on red)
+
+colord("#000000").isReadable(); // true (black on white)
+colord("#ffffff").isReadable("#000000"); // true (white on black)
+colord("#777777").isReadable(); // false (gray on white)
+colord("#e60000").isReadable("#ffff47"); // true (red on yellow conforms WCAG AA)
+colord("#e60000").isReadable("#ffff47", "AAA"); // false (red on yellow does not conform WCAG AAA)
+```
+
+</details>
 
 <details>
   <summary><b>CSS color names</b></summary>

--- a/README.md
+++ b/README.md
@@ -371,7 +371,7 @@ colord("#ffffff").luminance(); // 1
 </details>
 
 <details>
-  <summary><b><code>contrast(color2 = '#ffffff')</code></b> (<b>a11y</b> plugin)</summary>
+  <summary><b><code>contrast(color2 = "#FFF")</code></b> (<b>a11y</b> plugin)</summary>
 
 Calculates a contrast ratio for a color pair. This luminance difference is expressed as a ratio ranging from 1 (e.g. white on white) to 21 (e.g., black on a white). WCAG requires a ratio of at least 4.5 for normal text and 3 for large text.
 
@@ -389,7 +389,7 @@ colord("#0000ff").contrast("#ff000"); // 2.14 (blue on red)
 </details>
 
 <details>
-  <summary><b><code>isReadable(color2 = '#ffffff', level = 'AA')</code></b> (<b>a11y</b> plugin)</summary>
+  <summary><b><code>isReadable(color2 = "#FFF", level = "AA")</code></b> (<b>a11y</b> plugin)</summary>
 
 Checks a contrast between background and text colors. [WCAG 2.0 contrast ratio requirements](https://www.w3.org/TR/UNDERSTANDING-WCAG20/visual-audio-contrast-contrast.html) for a normal text:
 
@@ -413,7 +413,7 @@ colord("#e60000").isReadable("#ffff47", "AAA"); // false (red on yellow does not
 **Colord** has a built-in plugin system that allows new features and functionality to be easily added.
 
 <details>
-  <summary><b>Accessibility (A11y)</b></summary>
+  <summary><b>Accessibility (a11y)</b></summary>
 
 Adds accessibility and color contrast utilities working according to [Web Content Accessibility Guidelines 2.0](https://www.w3.org/TR/WCAG20/).
 

--- a/package.json
+++ b/package.json
@@ -107,6 +107,10 @@
       "limit": "2 KB"
     },
     {
+      "path": "dist/plugins/a11y.js",
+      "limit": "0.5 KB"
+    },
+    {
       "path": "dist/plugins/names.js",
       "limit": "1.5 KB"
     },

--- a/package.json
+++ b/package.json
@@ -26,7 +26,9 @@
   "main": "./dist/index.js",
   "browser": {
     ".": "./dist/index.js",
-    "./plugins/names": "./dist/plugins/names.js"
+    "./plugins/a11y": "./dist/plugins/a11y.js",
+    "./plugins/names": "./dist/plugins/names.js",
+    "./plugins/xyz": "./dist/plugins/xyz.js"
   },
   "exports": {
     ".": "./dist/index.js",

--- a/src/colorModels/rgba.ts
+++ b/src/colorModels/rgba.ts
@@ -25,3 +25,20 @@ export const parseRgba = ({ r, g, b, a = 1 }: InputObject): RgbaColor | null => 
     a: Number(a),
   });
 };
+
+/**
+ * Converts an RGB channel [0-255] to its linear light (un-companded) form [0-1].
+ * Linearized RGB values are widely used for color space conversions and contrast calculations
+ */
+export const linearizeRgbChannel = (value: number): number => {
+  const ratio = value / 255;
+  return ratio < 0.04045 ? ratio / 12.92 : Math.pow((ratio + 0.055) / 1.055, 2.4);
+};
+
+/**
+ * Converts an linear-light sRGB channel [0-1] back to its gamma corrected form [0-255]
+ */
+export const unlinearizeRgbChannel = (ratio: number): number => {
+  const value = ratio > 0.0031308 ? 1.055 * Math.pow(ratio, 1 / 2.4) - 0.055 : 12.92 * ratio;
+  return value * 255;
+};

--- a/src/colorModels/xyz.ts
+++ b/src/colorModels/xyz.ts
@@ -1,9 +1,9 @@
 import { InputObject, RgbaColor, XyzaColor } from "../types";
 import { clamp, isPresent, round } from "../helpers";
-import { clampRgba } from "./rgba";
+import { clampRgba, linearizeRgbChannel, unlinearizeRgbChannel } from "./rgba";
 
 /**
- * Limits XYZ axis values
+ * Limits XYZ axis values.
  * https://www.sttmedia.com/colormodel-xyz
  */
 export const clampXyza = ({ x, y, z, a }: XyzaColor): XyzaColor => ({
@@ -31,22 +31,6 @@ export const parseXyza = ({ x, y, z, a = 1 }: InputObject): RgbaColor | null => 
   });
 
   return xyzaToRgba(xyza);
-};
-
-/**
- * Converts an RGB channel [0-255] to its linear light (un-companded) form [0-1].
- */
-const linearizeRgbChannel = (value: number): number => {
-  const ratio = value / 255;
-  return ratio < 0.04045 ? ratio / 12.92 : Math.pow((ratio + 0.055) / 1.055, 2.4);
-};
-
-/**
- * Convert an linear-light sRGB channel [0-1] to its gamma corrected form [0-255].
- */
-const unlinearizeRgbChannel = (ratio: number): number => {
-  const value = ratio > 0.0031308 ? 1.055 * Math.pow(ratio, 1 / 2.4) - 0.055 : 12.92 * ratio;
-  return value * 255;
 };
 
 /**

--- a/src/get/getContrast.ts
+++ b/src/get/getContrast.ts
@@ -1,0 +1,12 @@
+import { RgbaColor } from "../types";
+import { getLuminance } from "./getLuminance";
+
+/**
+ * Returns a contrast ratio for a color pair [1-21].
+ * http://www.w3.org/TR/WCAG20/#contrast-ratiodef
+ */
+export const getContrast = (rgb1: RgbaColor, rgb2: RgbaColor): number => {
+  const l1 = getLuminance(rgb1);
+  const l2 = getLuminance(rgb2);
+  return l1 > l2 ? (l1 + 0.05) / (l2 + 0.05) : (l2 + 0.05) / (l1 + 0.05);
+};

--- a/src/get/getLuminance.ts
+++ b/src/get/getLuminance.ts
@@ -1,0 +1,14 @@
+import { linearizeRgbChannel } from "../colorModels/rgba";
+import { RgbaColor } from "../types";
+
+/**
+ * Returns the perceived luminance of a color [0-1] according to WCAG 2.0.
+ * https://www.w3.org/TR/WCAG20/#relativeluminancedef
+ */
+export const getLuminance = ({ r, g, b }: RgbaColor): number => {
+  const sRed = linearizeRgbChannel(r);
+  const sGreen = linearizeRgbChannel(g);
+  const sBlue = linearizeRgbChannel(b);
+
+  return 0.2126 * sRed + 0.7152 * sGreen + 0.0722 * sBlue;
+};

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -8,6 +8,10 @@ export const round = (number: number, digits = 0, base = Math.pow(10, digits)): 
   return Math.round(base * number) / base;
 };
 
+export const floor = (number: number, digits = 0, base = Math.pow(10, digits)): number => {
+  return Math.floor(base * number) / base;
+};
+
 /**
  * Clamps a value between an upper and lower bound.
  * We use ternary operators because it makes the minified code

--- a/src/plugins/a11y.ts
+++ b/src/plugins/a11y.ts
@@ -1,0 +1,43 @@
+import { AnyColor } from "../types";
+import { Plugin } from "../extend";
+import { getContrast } from "../get/getContrast";
+import { getLuminance } from "../get/getLuminance";
+import { round, floor } from "../helpers";
+
+declare module "../colord" {
+  interface Colord {
+    /**
+     * Returns the relative luminance of a color,
+     * normalized to 0 for darkest black and 1 for lightest white.
+     * https://www.w3.org/TR/WCAG20/#relativeluminancedef
+     */
+    luminance(): number;
+    /**
+     * Calculates a contrast ratio for a color pair.
+     * This luminance difference is expressed as a ratio ranging
+     * from 1 (e.g. white on white) to 21 (e.g., black on a white).
+     * WCAG requires a ratio of at least 4.5 for normal text and 3 for large text.
+     * https://www.w3.org/TR/UNDERSTANDING-WCAG20/visual-audio-contrast-contrast.html
+     * https://webaim.org/articles/contrast/
+     */
+    contrast(color2?: AnyColor | Colord): number;
+  }
+}
+
+/**
+ * A plugin adding accessibility and color contrast utilities.
+ * Follows Web Content Accessibility Guidelines 2.0.
+ * https://www.w3.org/TR/WCAG20/
+ */
+const a11yPlugin: Plugin = (ColordClass): void => {
+  ColordClass.prototype.luminance = function () {
+    return round(getLuminance(this.rgba), 2);
+  };
+
+  ColordClass.prototype.contrast = function (color2 = "#ffffff") {
+    const instance2 = color2 instanceof ColordClass ? color2 : new ColordClass(color2);
+    return floor(getContrast(this.rgba, instance2.toRgba()), 2);
+  };
+};
+
+export default a11yPlugin;

--- a/src/plugins/a11y.ts
+++ b/src/plugins/a11y.ts
@@ -43,12 +43,12 @@ const a11yPlugin: Plugin = (ColordClass): void => {
     return round(getLuminance(this.rgba), 2);
   };
 
-  ColordClass.prototype.contrast = function (color2 = "#ffffff") {
+  ColordClass.prototype.contrast = function (color2 = "#FFF") {
     const instance2 = color2 instanceof ColordClass ? color2 : new ColordClass(color2);
     return floor(getContrast(this.rgba, instance2.toRgba()), 2);
   };
 
-  ColordClass.prototype.isReadable = function (color2 = "#ffffff", level = "AA") {
+  ColordClass.prototype.isReadable = function (color2 = "#FFF", level = "AA") {
     const min = level === "AAA" ? 7 : 4.5;
     return this.contrast(color2) >= min;
   };

--- a/tests/plugins.test.ts
+++ b/tests/plugins.test.ts
@@ -37,13 +37,15 @@ describe("a11y", () => {
     expect(colord("#777777").isReadable()).toBe(false);
     expect(colord("#e60000").isReadable("#ffff47")).toBe(true);
     expect(colord("#af085c").isReadable("#000000")).toBe(false);
+    expect(colord("#af085c").isReadable("#000000", { size: "large" })).toBe(true);
     expect(colord("#d53987").isReadable("#000000")).toBe(true);
-    expect(colord("#d53987").isReadable("#000000", "AAA")).toBe(false);
-    expect(colord("#e9dddd").isReadable("#864b7c", "AA")).toBe(true);
-    expect(colord("#e9dddd").isReadable("#864b7c", "AAA")).toBe(false);
-    expect(colord("#e9dddd").isReadable("#864b7c", "AAA")).toBe(false);
-    expect(colord("#e9dddd").isReadable("#67325e", "AAA")).toBe(true);
-    expect(colord("#e9dddd").isReadable(colord("#67325e"), "AAA")).toBe(true);
+    expect(colord("#d53987").isReadable("#000000", { level: "AAA" })).toBe(false);
+    expect(colord("#e9dddd").isReadable("#864b7c", { level: "AA" })).toBe(true);
+    expect(colord("#e9dddd").isReadable("#864b7c", { level: "AAA" })).toBe(false);
+    expect(colord("#e9dddd").isReadable("#864b7c", { level: "AAA", size: "large" })).toBe(true);
+    expect(colord("#e9dddd").isReadable("#67325e", { level: "AAA" })).toBe(true);
+
+    expect(colord("#e9dddd").isReadable(colord("#67325e"), { level: "AAA" })).toBe(true);
   });
 });
 

--- a/tests/plugins.test.ts
+++ b/tests/plugins.test.ts
@@ -28,6 +28,7 @@ describe("a11y", () => {
     expect(colord("#0079ad").contrast("#2e2e2e")).toBe(2.8);
     expect(colord("#e42189").contrast("#0d0330")).toBe(4.54);
     expect(colord("#fff4cc").contrast("#3a1209")).toBe(15);
+    expect(colord("#fff4cc").contrast(colord("#3a1209"))).toBe(15);
   });
 
   it("Check readability", () => {
@@ -42,6 +43,7 @@ describe("a11y", () => {
     expect(colord("#e9dddd").isReadable("#864b7c", "AAA")).toBe(false);
     expect(colord("#e9dddd").isReadable("#864b7c", "AAA")).toBe(false);
     expect(colord("#e9dddd").isReadable("#67325e", "AAA")).toBe(true);
+    expect(colord("#e9dddd").isReadable(colord("#67325e"), "AAA")).toBe(true);
   });
 });
 

--- a/tests/plugins.test.ts
+++ b/tests/plugins.test.ts
@@ -6,21 +6,42 @@ import xyzPlugin from "../src/plugins/xyz";
 describe("a11y", () => {
   extend([a11yPlugin]);
 
-  it("Returns the relative luminance of a color", () => {
-    // https://webaim.org/articles/contrast/
+  it("Returns the perceived luminance of a color", () => {
+    expect(colord("#000000").luminance()).toBe(0);
+    expect(colord("#e42189").luminance()).toBe(0.19);
+    expect(colord("#ff0000").luminance()).toBe(0.21);
+    expect(colord("#808080").luminance()).toBe(0.22);
+    expect(colord("#aabbcc").luminance()).toBe(0.48);
+    expect(colord("#ccddee").luminance()).toBe(0.71);
+    expect(colord("#ffffff").luminance()).toBe(1);
   });
 
   it("Calculates a contrast ratio for a color pair", () => {
     // https://webaim.org/resources/contrastchecker/
     expect(colord("#000000").contrast()).toBe(21);
     expect(colord("#ffffff").contrast("#000000")).toBe(21);
+    expect(colord("#777777").contrast()).toBe(4.47);
     expect(colord("#ff0000").contrast()).toBe(3.99);
     expect(colord("#00ff00").contrast()).toBe(1.37);
-    expect(colord("#2E2E2E").contrast()).toBe(13.57);
-    expect(colord("#0079AD").contrast()).toBe(4.84);
-    expect(colord("#0079AD").contrast("#2E2E2E")).toBe(2.8);
-    expect(colord("#E42189").contrast("#0D0330")).toBe(4.54);
-    expect(colord("#FFF4CC").contrast("#3A1209")).toBe(15);
+    expect(colord("#2e2e2e").contrast()).toBe(13.57);
+    expect(colord("#0079ad").contrast()).toBe(4.84);
+    expect(colord("#0079ad").contrast("#2e2e2e")).toBe(2.8);
+    expect(colord("#e42189").contrast("#0d0330")).toBe(4.54);
+    expect(colord("#fff4cc").contrast("#3a1209")).toBe(15);
+  });
+
+  it("Check readability", () => {
+    // https://webaim.org/resources/contrastchecker/
+    expect(colord("#000").isReadable()).toBe(true);
+    expect(colord("#777777").isReadable()).toBe(false);
+    expect(colord("#e60000").isReadable("#ffff47")).toBe(true);
+    expect(colord("#af085c").isReadable("#000000")).toBe(false);
+    expect(colord("#d53987").isReadable("#000000")).toBe(true);
+    expect(colord("#d53987").isReadable("#000000", "AAA")).toBe(false);
+    expect(colord("#e9dddd").isReadable("#864b7c", "AA")).toBe(true);
+    expect(colord("#e9dddd").isReadable("#864b7c", "AAA")).toBe(false);
+    expect(colord("#e9dddd").isReadable("#864b7c", "AAA")).toBe(false);
+    expect(colord("#e9dddd").isReadable("#67325e", "AAA")).toBe(true);
   });
 });
 

--- a/tests/plugins.test.ts
+++ b/tests/plugins.test.ts
@@ -1,6 +1,28 @@
 import { colord, extend } from "../src/";
+import a11yPlugin from "../src/plugins/a11y";
 import namesPlugin from "../src/plugins/names";
 import xyzPlugin from "../src/plugins/xyz";
+
+describe("a11y", () => {
+  extend([a11yPlugin]);
+
+  it("Returns the relative luminance of a color", () => {
+    // https://webaim.org/articles/contrast/
+  });
+
+  it("Calculates a contrast ratio for a color pair", () => {
+    // https://webaim.org/resources/contrastchecker/
+    expect(colord("#000000").contrast()).toBe(21);
+    expect(colord("#ffffff").contrast("#000000")).toBe(21);
+    expect(colord("#ff0000").contrast()).toBe(3.99);
+    expect(colord("#00ff00").contrast()).toBe(1.37);
+    expect(colord("#2E2E2E").contrast()).toBe(13.57);
+    expect(colord("#0079AD").contrast()).toBe(4.84);
+    expect(colord("#0079AD").contrast("#2E2E2E")).toBe(2.8);
+    expect(colord("#E42189").contrast("#0D0330")).toBe(4.54);
+    expect(colord("#FFF4CC").contrast("#3A1209")).toBe(15);
+  });
+});
 
 describe("names", () => {
   extend([namesPlugin]);


### PR DESCRIPTION
Closes #11

A plugin adding accessibility and color contrast utilities. Strictly follows Web Content Accessibility Guidelines 2.0.

- [x] `color.luminance()` [0-1]
- [x] `color1.contrast(color2 = '#ffffff')` [1-21]
- [x] `color1.isReadable(color2 = '#ffffff', level = 'AA')` — alias for `color1.contrast(color2) >= 4.5 | 7`.

See updated README for more details, links and examples.