### PR TITLE
Do not add 100% alpha to strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ The library's parser cares about you and tries to prevent as many mistakes and t
 
 ```js
 colord(" aBc ").toHex(); // "#aabbcc"
-colord("__rGbA 10 20,  999...").toRgbaString(); // "rgba(10, 20, 255, 1)"
+colord("__rGbA 10 20,  999...").toRgbaString(); // "rgb(10, 20, 255)"
 colord(" hsL(  10, 200% 30 .5!!!").toHslaString(); // "hsla(10, 100%, 30%, 0.5)"
 ```
 
@@ -142,7 +142,7 @@ colord({ h: 180, s: 100, l: 50, a: 0.5 }).toRgba(); // { r: 0, g: 255, b: 255, a
   <summary><b><code>toRgbaString()</code></b></summary>
 
 ```js
-colord("#ff0000").toRgbaString(); // "rgba(255, 0, 0, 1)"
+colord("#ff0000").toRgbaString(); // "rgb(255, 0, 0)"
 colord({ h: 180, s: 100, l: 50, a: 0.5 }).toRgbaString(); // "rgba(0, 255, 255, 0.5)"
 ```
 
@@ -166,7 +166,7 @@ colord("rgba(0, 0, 255, 0.5) ").toHsla(); // { h: 240, s: 100, l: 50, a: 0.5 }
 Converts a color to [HSL color space](https://en.wikipedia.org/wiki/HSL_and_HSV) and expresses it through the [functional notation](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value#hsl_colors).
 
 ```js
-colord("#ffff00").toHsla(); // "hsla(60, 100%, 50%, 1)"
+colord("#ffff00").toHsla(); // "hsl(60, 100%, 50%)"
 colord("rgba(0, 0, 255, 0.5)").toHsla(); // "hsla(240, 100%, 50%, 0.5)"
 ```
 
@@ -250,7 +250,7 @@ Increases the [HSL saturation](https://en.wikipedia.org/wiki/HSL_and_HSV) of a c
 
 ```js
 colord("#bf4040").saturate(0.25).toHex(); // "#df2020"
-colord("hsla(0, 50%, 50%, 1)").saturate(0.5).toHslaString(); // "hsla(0, 100%, 50%, 1)"
+colord("hsl(0, 50%, 50%)").saturate(0.5).toHslaString(); // "hsl(0, 100%, 50%)"
 ```
 
 </details>
@@ -262,7 +262,7 @@ Decreases the [HSL saturation](https://en.wikipedia.org/wiki/HSL_and_HSV) of a c
 
 ```js
 colord("#df2020").saturate(0.25).toHex(); // "#bf4040"
-colord("hsla(0, 100%, 50%, 1)").saturate(0.5).toHslaString(); // "hsla(0, 50%, 50%, 1)"
+colord("hsl(0, 100%, 50%)").saturate(0.5).toHslaString(); // "hsl(0, 50%, 50%)"
 ```
 
 </details>
@@ -274,7 +274,7 @@ Makes a gray color with the same lightness as a source color. Same as calling `d
 
 ```js
 colord("#bf4040").grayscale().toHex(); // "#808080"
-colord("hsla(0, 100%, 50%, 1)").grayscale().toHslaString(); // "hsla(0, 0%, 50%, 1)"
+colord("hsl(0, 100%, 50%)").grayscale().toHslaString(); // "hsl(0, 0%, 50%)"
 ```
 
 </details>
@@ -287,7 +287,7 @@ Increases the [HSL lightness](https://en.wikipedia.org/wiki/HSL_and_HSV) of a co
 ```js
 colord("#000000").lighten(0.5).toHex(); // "#808080"
 colord("#223344").lighten(0.3).toHex(); // "#5580aa"
-colord("hsla(0, 50%, 50%, 1)").lighten(0.5).toHslaString(); // "hsla(0, 50%, 100%, 1)"
+colord("hsl(0, 50%, 50%)").lighten(0.5).toHslaString(); // "hsl(0, 50%, 100%)"
 ```
 
 </details>
@@ -300,7 +300,7 @@ Decreases the [HSL lightness](https://en.wikipedia.org/wiki/HSL_and_HSV) of a co
 ```js
 colord("#ffffff").darken(0.5).toHex(); // "#808080"
 colord("#5580aa").darken(0.3).toHex(); // "#223344"
-colord("hsla(0, 50%, 100%, 1)").lighten(0.5).toHslaString(); // "hsla(0, 50%, 50%, 1)"
+colord("hsl(0, 50%, 100%)").lighten(0.5).toHslaString(); // "hsl(0, 50%, 50%)"
 ```
 
 </details>

--- a/src/colorModels/hslaString.ts
+++ b/src/colorModels/hslaString.ts
@@ -20,5 +20,5 @@ export const parseHslaString = (input: string): RgbaColor | null => {
 
 export const rgbaToHslaString = (rgba: RgbaColor): string => {
   const { h, s, l, a } = rgbaToHsla(rgba);
-  return `hsla(${h}, ${s}%, ${l}%, ${a})`;
+  return a < 1 ? `hsla(${h}, ${s}%, ${l}%, ${a})` : `hsl(${h}, ${s}%, ${l}%)`;
 };

--- a/src/colorModels/rgbaString.ts
+++ b/src/colorModels/rgbaString.ts
@@ -18,5 +18,5 @@ export const parseRgbaString = (input: string): RgbaColor | null => {
 
 export const rgbaToRgbaString = (rgba: RgbaColor): string => {
   const { r, g, b, a } = roundRgba(rgba);
-  return `rgba(${r}, ${g}, ${b}, ${a})`;
+  return a < 1 ? `rgba(${r}, ${g}, ${b}, ${a})` : `rgb(${r}, ${g}, ${b})`;
 };

--- a/tests/colord.test.ts
+++ b/tests/colord.test.ts
@@ -21,11 +21,18 @@ it("Parses and converts a color", () => {
     const instance = colord(lime[format] as AnyColor);
     expect(instance.toHex()).toBe(lime.hex);
     expect(instance.toRgba()).toMatchObject(lime.rgba);
-    expect(instance.toRgbaString()).toBe(lime.rgbaString);
+    expect(instance.toRgbaString()).toBe(lime.rgbString);
     expect(instance.toHsla()).toMatchObject(lime.hsla);
-    expect(instance.toHslaString()).toBe(lime.hslaString);
+    expect(instance.toHslaString()).toBe(lime.hslString);
     expect(instance.toHsva()).toMatchObject(lime.hsva);
   }
+});
+
+it("Adds alpha number to RGB and HSL strings only if the color has an opacity", () => {
+  expect(colord("rgb(0, 0, 0)").toRgbaString()).toBe("rgb(0, 0, 0)");
+  expect(colord("hsl(0, 0%, 0%)").toHslaString()).toBe("hsl(0, 0%, 0%)");
+  expect(colord("rgb(0, 0, 0)").alpha(0.5).toRgbaString()).toBe("rgba(0, 0, 0, 0.5)");
+  expect(colord("hsl(0, 0%, 0%)").alpha(0.5).toHslaString()).toBe("hsla(0, 0%, 0%, 0.5)");
 });
 
 it("Supports HEX4 and HEX8 color models", () => {
@@ -88,9 +95,9 @@ it("Saturates and desaturates a color", () => {
 });
 
 it("Makes a color lighter and darker", () => {
-  expect(colord("hsl(100, 50%, 50%)").lighten().toHslaString()).toBe("hsla(100, 50%, 60%, 1)");
+  expect(colord("hsl(100, 50%, 50%)").lighten().toHslaString()).toBe("hsl(100, 50%, 60%)");
   expect(colord("hsl(100, 50%, 50%)").lighten(0.25).toHsla().l).toBe(75);
-  expect(colord("hsl(100, 50%, 50%)").darken().toHslaString()).toBe("hsla(100, 50%, 40%, 1)");
+  expect(colord("hsl(100, 50%, 50%)").darken().toHslaString()).toBe("hsl(100, 50%, 40%)");
   expect(colord("hsl(100, 50%, 50%)").darken(0.25).toHsla().l).toBe(25);
 
   expect(colord("#000").lighten(1).toHex()).toBe("#ffffff");


### PR DESCRIPTION
It is a pattern used by all popular libraries, so I decided to mimic it.