### PR TITLE
Publish CJS for better Node.js support

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@
 - 🛡 **Bulletproof**: Written in strict TypeScript and 100% covered by tests
 - 🗂 **Typed**: All [types are available](#types) out of the box
 - 🏗 **Extendable**: Built-in [plugin system](#plugins) to add new functionality
-- 👫 **Works everywhere**: Supports all browsers and Node 12+
+- 👫 **Works everywhere**: Supports all browsers and Node.js
 - 💨 **Dependency-free**
 
 <div><img src="assets/divider.png" width="838" alt="---" /></div>

--- a/package.json
+++ b/package.json
@@ -20,21 +20,21 @@
   "license": "MIT",
   "sideEffects": false,
   "type": "module",
+  "module": "./index.js",
   "main": "./index.cjs",
-  "module": "./index.mjs",
   "exports": {
     ".": {
-      "import": "./index.mjs",
+      "import": "./index.js",
       "require": "./index.cjs"
     },
     "./plugins/*": {
-      "import": "./plugins/*.mjs",
+      "import": "./plugins/*.js",
       "require": "./plugins/*.cjs"
     }
   },
   "files": [
-    "*.{mjs,cjs,ts,map}",
-    "plugins/*.{mjs,cjs,ts,map}"
+    "*.{js,cjs,ts,map}",
+    "plugins/*.{js,cjs,ts,map}"
   ],
   "types": "index.d.ts",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -20,32 +20,23 @@
   "license": "MIT",
   "sideEffects": false,
   "type": "module",
-  "engines": {
-    "node": ">=12"
-  },
-  "main": "./dist/index.js",
-  "browser": {
-    ".": "./dist/index.js",
-    "./plugins/a11y": "./dist/plugins/a11y.js",
-    "./plugins/names": "./dist/plugins/names.js",
-    "./plugins/xyz": "./dist/plugins/xyz.js"
-  },
+  "main": "./index.cjs",
+  "module": "./index.mjs",
   "exports": {
-    ".": "./dist/index.js",
-    "./plugins/*": "./dist/plugins/*.js"
-  },
-  "files": [
-    "dist/*.{js,ts,map}",
-    "dist/plugins/*.{js,ts,map}"
-  ],
-  "types": "dist/index.d.ts",
-  "typesVersions": {
-    "*": {
-      "plugins/*": [
-        "dist/plugins/*"
-      ]
+    ".": {
+      "import": "./index.mjs",
+      "require": "./index.cjs"
+    },
+    "./plugins/*": {
+      "import": "./plugins/*.mjs",
+      "require": "./plugins/*.cjs"
     }
   },
+  "files": [
+    "*.{mjs,cjs,ts,map}",
+    "plugins/*.{mjs,cjs,ts,map}"
+  ],
+  "types": "index.d.ts",
   "scripts": {
     "lint": "eslint src/**/*.ts",
     "size": "npm run build && size-limit",
@@ -53,7 +44,8 @@
     "test": "jest tests --coverage",
     "benchmark": "node --experimental-specifier-resolution node --loader ts-node/esm ./tests/benchmark.ts",
     "build": "rm -rf ./dist/* && rollup --config",
-    "prepublishOnly": "npm run build"
+    "release": "npm run build && cp *.json dist && cp *.md dist && npm publish dist",
+    "check-release": "npm run release -- --dry-run"
   },
   "dependencies": {},
   "devDependencies": {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -28,7 +28,7 @@ export default [
   {
     input: "src/index.ts",
     output: {
-      file: "dist/index.mjs",
+      file: "dist/index.js",
       format: "es",
     },
     plugins: getRollupPluginsConfig({ declaration: true }),
@@ -46,7 +46,7 @@ export default [
   ...colordPluginPaths.map((input) => ({
     input,
     output: {
-      file: `dist/plugins/${path.parse(input).name}.mjs`,
+      file: `dist/plugins/${path.parse(input).name}.js`,
       format: "es",
     },
     plugins: getRollupPluginsConfig({ declaration: false }),

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,3 +1,4 @@
+import path from "path";
 import glob from "glob";
 import typescript from "rollup-plugin-typescript2";
 import { terser } from "rollup-plugin-terser";
@@ -17,23 +18,47 @@ const getRollupPluginsConfig = (compilerOptions) => {
   ];
 };
 
+// Find available plugins
+const colordPluginPaths = glob.sync("./src/plugins/*.ts");
+
+// Bundle both formats according to NodeJS guide
+// https://nodejs.org/api/packages.html#packages_approach_2_isolate_state
 export default [
-  // Build the main bundle
+  // Build the main bundle in both ESM and CJS modules
   {
     input: "src/index.ts",
     output: {
-      dir: "dist",
+      file: "dist/index.mjs",
       format: "es",
     },
     plugins: getRollupPluginsConfig({ declaration: true }),
   },
+  {
+    input: "src/index.ts",
+    output: {
+      file: "dist/index.cjs",
+      format: "cjs",
+    },
+    plugins: getRollupPluginsConfig({ declaration: false }),
+  },
 
-  // Bundle all colord plugins
-  ...glob.sync("./src/plugins/*.ts").map((input) => ({
+  // Bundle all library plugins as ESM modules
+  ...colordPluginPaths.map((input) => ({
     input,
     output: {
-      dir: "dist/plugins",
+      file: `dist/plugins/${path.parse(input).name}.mjs`,
       format: "es",
+    },
+    plugins: getRollupPluginsConfig({ declaration: false }),
+  })),
+
+  // Bundle all library plugins as CommonJS modules
+  ...colordPluginPaths.map((input) => ({
+    input,
+    output: {
+      file: `dist/plugins/${path.parse(input).name}.cjs`,
+      format: "cjs",
+      exports: "default",
     },
     plugins: getRollupPluginsConfig({ declaration: false }),
   })),


### PR DESCRIPTION
Closes #15 

Make the package dual ESM and CJS according to [the official Node guide](https://nodejs.org/api/packages.html#packages_dual_commonjs_es_module_packages).