### PR TITLE
Names plugin: Support 'transparent' color

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,9 +196,10 @@ import namesPlugin from "colord/plugins/names";
 
 extend([namesPlugin]);
 
-colord("ff6347").toName(); // "tomato"
+colord("#ff6347").toName(); // "tomato"
 colord("#00ffff").toName(); // "cyan"
 colord("#aabbcc").toName(); // undefined (the color is not specified in CSS specs)
+colord("rgba(0, 0, 0, 0)").toName(); // "transparent"
 ```
 
 </details>
@@ -451,6 +452,7 @@ extend([namesPlugin]);
 colord("tomato").toHex(); // "#ff6347"
 colord("#00ffff").toName(); // "cyan"
 colord("#aabbcc").toName(); // undefined (the color is not specified in CSS specs)
+colord("rgba(0, 0, 0, 0)").toName(); // "transparent"
 ```
 
 </details>
@@ -506,5 +508,6 @@ const bar: RgbColor = { r: 0, g: 0, v: 0 }; // ERROR
 - [x] A11y and contrast utils (via plugin)
 - [ ] CMYK color space (via plugin)
 - [x] XYZ color space (via plugin)
+- [ ] [HWB](https://drafts.csswg.org/css-color/#the-hwb-notation) color space (via plugin)
 - [ ] [LAB](https://www.w3.org/TR/css-color-4/#resolving-lab-lch-values) color space (via plugin)
 - [ ] [LCH](https://lea.verou.me/2020/04/lch-colors-in-css-what-why-and-how/) color space (via plugin)

--- a/src/plugins/names.ts
+++ b/src/plugins/names.ts
@@ -11,6 +11,8 @@ declare module "../colord" {
  * Plugin to work with named colors.
  * Adds a parser to read CSS color names and `toName` method.
  * See https://www.w3.org/TR/css-color-4/#named-colors
+ * Supports 'transparent' string as defined in
+ * https://drafts.csswg.org/css-color/#transparent-color
  */
 const namesPlugin: Plugin = (ColordClass, parsers): void => {
   // The default CSS color names dictionary
@@ -171,12 +173,14 @@ const namesPlugin: Plugin = (ColordClass, parsers): void => {
 
   // Define new color conversion method
   ColordClass.prototype.toName = function () {
+    if (this.rgba.a === 0) return "transparent";
     return HEX_NAME_STORE[this.toHex()] || undefined;
   };
 
-  // Add CSS color names parser
+  // Add CSS color names parser.
   const parseColorName: Parser<string> = (input: string): RgbaColor | null => {
-    const hex = NAME_HEX_STORE[input.trim()];
+    const name = input.trim();
+    const hex = name === "transparent" ? "#0000" : NAME_HEX_STORE[name];
     if (hex) return new ColordClass(hex).toRgba();
     return null;
   };

--- a/tests/plugins.test.ts
+++ b/tests/plugins.test.ts
@@ -66,6 +66,12 @@ describe("names", () => {
     expect(colord("#123456").toName()).toBe(undefined);
     expect(colord("myownpurple").toHex()).toBe("#000000");
   });
+
+  it("Processes 'transparent' color properly", () => {
+    expect(colord("transparent").alpha()).toBe(0);
+    expect(colord("transparent").toHex()).toBe("#00000000");
+    expect(colord("rgba(0, 0, 0, 0)").toName()).toBe("transparent");
+  });
 });
 
 describe("xyz", () => {


### PR DESCRIPTION
`"transparent"` is a part of the named colors specification so it makes sense to support this keyword.

See https://drafts.csswg.org/css-color/#named-colors