### PR TITLE
Add `isValid` method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 1.1.0
+
+- Add `isValid` method
+
 ### 1.0
 
 - An official production-ready release

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@
 
 ## Features
 
-- 📦 **Small**: Just **1.4 KB** gzipped ([3x+ lighter](#benchmarks) than **color** and **tinycolor2**)
+- 📦 **Small**: Just **1.5 KB** gzipped ([3x+ lighter](#benchmarks) than **color** and **tinycolor2**)
 - 🚀 **Fast**: [2x+ faster](#benchmarks) than **color** and **tinycolor2**
 - 😍 **Simple**: Chainable API and familiar patterns
 - 💪 **Immutable**: No need to worry about data mutations
@@ -326,6 +326,22 @@ colord("hsl(0, 50%, 100%)").lighten(0.5).toHslString(); // "hsl(0, 50%, 50%)"
 </details>
 
 ### Color analysis
+
+<details>
+  <summary><b><code>isValid()</code></b></summary>
+
+Returns a boolean indicating whether or not an input has been parsed successfully.
+Note: If parsing is unsuccessful, Colord defaults to black (does not throws an error).
+
+```js
+colord("#ffffff").isValid(); // true
+colord("#wwuutt").isValid(); // false
+colord("abracadabra").isValid(); // false
+colord({ r: 0, g: 0, b: 0 }).isValid(); // true
+colord({ r: 0, g: 0, v: 0 }).isValid(); // false
+```
+
+</details>
 
 <details>
   <summary><b><code>alpha()</code></b></summary>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "colord",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "👑 A tiny yet powerful tool for high-performance color manipulations and conversions",
   "keywords": [
     "color",

--- a/src/colord.ts
+++ b/src/colord.ts
@@ -14,12 +14,22 @@ import { lighten } from "./manipulate/lighten";
 import { invert } from "./manipulate/invert";
 
 export class Colord {
+  private readonly parsed: RgbaColor | null;
   readonly rgba: RgbaColor;
 
   constructor(input: AnyColor) {
     // Internal color format is RGBA object.
-    // We do not round interval RGBA numbers for better conversion accuracy
-    this.rgba = parse(input as Input) || { r: 0, g: 0, b: 0, a: 1 };
+    // We do not round the internal RGBA numbers for better conversion accuracy.
+    this.parsed = parse(input as Input);
+    this.rgba = this.parsed || { r: 0, g: 0, b: 0, a: 1 };
+  }
+
+  /**
+   * Returns a boolean indicating whether or not an input has been parsed successfully.
+   * Note: If parsing is unsuccessful, Colord defaults to black (does not throws an error).
+   */
+  public isValid(): boolean {
+    return this.parsed !== null;
   }
 
   /**

--- a/tests/colord.test.ts
+++ b/tests/colord.test.ts
@@ -99,6 +99,21 @@ it("Does not crash when input has an invalid format", () => {
   expect(colord("WUT?").toRgb()).toMatchObject(fallbackRgba);
 });
 
+it("Validates an input value", () => {
+  expect(colord("#ffffff").isValid()).toBe(true);
+  expect(colord("#0011gg").isValid()).toBe(false);
+  expect(colord("abracadabra").isValid()).toBe(false);
+  expect(colord("rgba(0,0,0,1)").isValid()).toBe(true);
+  expect(colord("hsla(100,50%,50%,1)").isValid()).toBe(true);
+  expect(colord({ r: 255, g: 255, b: 255 }).isValid()).toBe(true);
+  // @ts-ignore
+  expect(colord({ r: 255, g: 255, v: 255 }).isValid()).toBe(false);
+  // @ts-ignore
+  expect(colord({ h: 0, w: 0, l: 0 }).isValid()).toBe(false);
+  // @ts-ignore
+  expect(colord({ w: 1, u: 2, t: 3 }).isValid()).toBe(false);
+});
+
 it("Saturates and desaturates a color", () => {
   const instance = colord(saturationLevels[5]);
   expect(instance.saturate(0.2).toHex()).toBe(saturationLevels[7]);

--- a/tests/plugins.test.ts
+++ b/tests/plugins.test.ts
@@ -93,6 +93,13 @@ describe("names", () => {
     expect(colord("transparent").toHex()).toBe("#00000000");
     expect(colord("rgba(0, 0, 0, 0)").toName()).toBe("transparent");
   });
+
+  it("Works properly in pair with the built-in validation", () => {
+    expect(colord("transparent").isValid()).toBe(true);
+    expect(colord("red").isValid()).toBe(true);
+    expect(colord("yellow").isValid()).toBe(true);
+    expect(colord("sunyellow").isValid()).toBe(false);
+  });
 });
 
 describe("xyz", () => {


### PR DESCRIPTION
Checked dozens of projects using `tinycolor` and noticed that a lot of developers use `isValid` method to check their values.
Since it not a big deal to implement a method doing the same and the new code costs about 0,02KB, I decided to implement that.