### PR TITLE
Clamp NaN values

### DIFF
--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -16,7 +16,8 @@ export const floor = (number: number, digits = 0, base = Math.pow(10, digits)): 
  * Clamps a value between an upper and lower bound.
  * We use ternary operators because it makes the minified code
  * is 2 times shorter then `Math.min(Math.max(a,b),c)`
+ * NaN is clamped to the lower bound
  */
 export const clamp = (number: number, min = 0, max = 1): number => {
-  return number > max ? max : number < min ? min : number;
+  return number > max ? max : number > min ? number : min;
 };

--- a/tests/colord.test.ts
+++ b/tests/colord.test.ts
@@ -72,6 +72,22 @@ it("Parses invalid color string", () => {
 it("Clamps input numbers", () => {
   expect(colord("rgba(256, 999, -200, 2)").toRgb()).toMatchObject({ r: 255, g: 255, b: 0, a: 1 });
   expect(colord("hsla(-999, 200, 50, 2)").toHsl()).toMatchObject({ h: 0, s: 100, l: 50, a: 1 });
+  expect(
+    colord({
+      r: NaN,
+      g: -Infinity,
+      b: +Infinity,
+      a: 100500,
+    }).toRgb()
+  ).toMatchObject({ r: 0, g: 0, b: 255, a: 1 });
+  expect(
+    colord({
+      h: NaN,
+      s: -Infinity,
+      l: +Infinity,
+      a: 100500,
+    }).toHsl()
+  ).toMatchObject({ h: 0, s: 0, l: 100, a: 1 });
 });
 
 it("Accepts a colord instance as an input", () => {


### PR DESCRIPTION
As I can see, Colord is generally very tolerable to the garbage input. But the NaN values (and ones that are coerced to NaN) are not handled:

```
colord({r: 'foo', g: 'bar', b: 'baz'}).toRgb()
{ r: NaN, g: NaN, b: NaN, a: 1 }
```
```
colord({r: 'foo', g: 'bar', b: 'baz'}).toHex()
'#NaNNaNNaN'
```

This is a proposed fix: To treat NaN values as a finite lower bound in `clamp()`