### PR TITLE
New plugin: mix

### DIFF
--- a/README.md
+++ b/README.md
@@ -378,6 +378,27 @@ colord("hsl(0, 50%, 100%)").lighten(0.5).toHslString(); // "hsl(0, 50%, 50%)"
 
 </details>
 
+<details>
+  <summary><b><code>mix(color2, ratio = 0.5)</code></b> (<b>mix</b> plugin)</summary>
+
+Produces a mixture of two colors and returns the result of mixing them (new Colord instance).
+
+In contrast to other libraries that perform RGB values mixing, Colord mixes colors through LCH color space — same way the new CSS [`color-mix` function](https://drafts.csswg.org/css-color-5/#funcdef-color-mix) works. This approach produces better results and doesn't have the drawbacks the legacy way has.
+
+```js
+import { colord, extend } from "colord";
+import mixPlugin from "colord/plugins/mix";
+
+extend([mixPlugin]);
+
+colord("#ffffff").mix("#000000").toHex(); // "#777777"
+colord("#800080").mix("#dda0dd").toHex(); // "#af5cae"
+colord("#cd853f").mix("#eee8aa", 0.6).toHex(); // "#dfc279"
+colord("#008080").mix("#808000", 0.35).toHex(); // "#14865f"
+```
+
+</details>
+
 ### Color analysis
 
 <details>
@@ -546,7 +567,7 @@ colord({ h: 0, w: 100, b: 0, a: 1 }).toHex(); // "#ffffff"
 </details>
 
 <details>
-  <summary><b><code>lab</code> (CIE LAB color space)</b> <i>0.78 KB</i></summary>
+  <summary><b><code>lab</code> (CIE LAB color space)</b> <i>0.9 KB</i></summary>
 
 Adds support of [CIE LAB](https://en.wikipedia.org/wiki/CIELAB_color_space) color model. The conversion logic is ported from [CSS Color Module Level 4 Specification](https://www.w3.org/TR/css-color-4/#color-conversion-code).
 
@@ -563,7 +584,7 @@ colord("#ffffff").toLab(); // { l: 100, a: 0, b: 0, alpha: 1 }
 </details>
 
 <details>
-  <summary><b><code>lch</code> (CIE LCH color space)</b> <i>1 KB</i></summary>
+  <summary><b><code>lch</code> (CIE LCH color space)</b> <i>1.2 KB</i></summary>
 
 Adds support of [CIE LCH](https://lea.verou.me/2020/04/lch-colors-in-css-what-why-and-how/) color space. The conversion logic is ported from [CSS Color Module Level 4 Specification](https://www.w3.org/TR/css-color-4/#color-conversion-code).
 
@@ -578,6 +599,27 @@ colord("lch(48.25% 30.07 196.38)").toHex(); // "#008080"
 
 colord("#646464").toLch(); // { l: 42.37, c: 0, h: 0, a: 1 }
 colord("#646464").alpha(0.5).toLchString(); // "lch(42.37% 0 0 / 0.5)"
+```
+
+</details>
+
+<details>
+  <summary><b><code>mix</code> (Color mixing)</b> <i>0.97 KB</i></summary>
+
+A plugin adding a color mixing utility.
+
+In contrast to other libraries that perform RGB values mixing, Colord mixes colors through LCH color space — same way the new CSS [`color-mix` function](https://drafts.csswg.org/css-color-5/#funcdef-color-mix) works. This approach produces better results and doesn't have the drawbacks the legacy way has.
+
+```js
+import { colord, extend } from "colord";
+import mixPlugin from "colord/plugins/mix";
+
+extend([mixPlugin]);
+
+colord("#ffffff").mix("#000000").toHex(); // "#777777"
+colord("#800080").mix("#dda0dd").toHex(); // "#af5cae"
+colord("#cd853f").mix("#eee8aa", 0.6).toHex(); // "#dfc279"
+colord("#008080").mix("#808000", 0.35).toHex(); // "#14865f"
 ```
 
 </details>
@@ -602,7 +644,7 @@ colord("rgba(0, 0, 0, 0)").toName(); // "transparent"
 </details>
 
 <details>
-  <summary><b><code>xyz</code> (CIE XYZ color space)</b> <i>0.6 KB</i></summary>
+  <summary><b><code>xyz</code> (CIE XYZ color space)</b> <i>0.7 KB</i></summary>
 
 Adds support of [CIE XYZ](https://www.sttmedia.com/colormodel-xyz) color model. The conversion logic is ported from [CSS Color Module Level 4 Specification](https://www.w3.org/TR/css-color-4/#color-conversion-code).
 
@@ -653,5 +695,5 @@ const bar: RgbColor = { r: 0, g: 0, v: 0 }; // ERROR
 - [x] [HWB](https://drafts.csswg.org/css-color/#the-hwb-notation) color space (via plugin)
 - [x] [LAB](https://www.w3.org/TR/css-color-4/#resolving-lab-lch-values) color space (via plugin)
 - [x] [LCH](https://lea.verou.me/2020/04/lch-colors-in-css-what-why-and-how/) color space (via plugin)
+- [x] Mix colors (via plugin)
 - [ ] CMYK color space (via plugin)
-- [ ] Mix colors (via plugin)

--- a/package.json
+++ b/package.json
@@ -119,7 +119,7 @@
     },
     {
       "path": "dist/plugins/lch.mjs",
-      "limit": "1.1 KB"
+      "limit": "1.25 KB"
     },
     {
       "path": "dist/plugins/mix.mjs",

--- a/package.json
+++ b/package.json
@@ -122,6 +122,10 @@
       "limit": "1.1 KB"
     },
     {
+      "path": "dist/plugins/mix.mjs",
+      "limit": "1 KB"
+    },
+    {
       "path": "dist/plugins/names.mjs",
       "limit": "1.5 KB"
     },

--- a/src/colorModels/lab.ts
+++ b/src/colorModels/lab.ts
@@ -20,8 +20,8 @@ export const clampLaba = (laba: LabaColor): LabaColor => ({
 
 export const roundLaba = (laba: LabaColor): LabaColor => ({
   l: round(laba.l, 2),
-  a: round(laba.a, 2),
-  b: round(laba.b, 2),
+  a: round(laba.a, 2) + 0,
+  b: round(laba.b, 2) + 0,
   alpha: round(laba.alpha, 2),
 });
 
@@ -43,11 +43,11 @@ export const parseLaba = ({ l, a, b, alpha = 1 }: InputObject): RgbaColor | null
  * https://www.w3.org/TR/css-color-4/#color-conversion-code
  */
 export const rgbaToLaba = (rgba: RgbaColor): LabaColor => {
-  // Compute XYZ scaled relative to D65 reference white
+  // Compute XYZ scaled relative to D50 reference white
   const xyza = rgbaToXyza(rgba);
-  let x = xyza.x / 95.047;
+  let x = xyza.x / 96.422;
   let y = xyza.y / 100;
-  let z = xyza.z / 108.883;
+  let z = xyza.z / 82.521;
 
   x = x > e ? Math.cbrt(x) : k * x + 16 / 116;
   y = y > e ? Math.cbrt(y) : k * y + 16 / 116;
@@ -71,9 +71,9 @@ export const labaToRgba = (laba: LabaColor): RgbaColor => {
   const z = y - laba.b / 200;
 
   return xyzaToRgba({
-    x: (x ** 3 > e ? x ** 3 : (x - 16 / 116) / k) * 95.047,
+    x: (x ** 3 > e ? x ** 3 : (x - 16 / 116) / k) * 96.42,
     y: (y ** 3 > e ? y ** 3 : (y - 16 / 116) / k) * 100,
-    z: (z ** 3 > e ? z ** 3 : (z - 16 / 116) / k) * 108.883,
+    z: (z ** 3 > e ? z ** 3 : (z - 16 / 116) / k) * 82.52,
     a: laba.alpha,
   });
 };

--- a/src/colorModels/lch.ts
+++ b/src/colorModels/lch.ts
@@ -40,11 +40,16 @@ export const parseLcha = ({ l, c, h, a = 1 }: InputObject): RgbaColor | null => 
  */
 export const rgbaToLcha = (rgba: RgbaColor): LchaColor => {
   const laba = rgbaToLaba(rgba);
-  const hue = (Math.atan2(laba.b, laba.a) * 180) / Math.PI;
+
+  // Round axis values to get proper values for grayscale colors
+  const a = round(laba.a, 3) + 0;
+  const b = round(laba.b, 3) + 0;
+
+  const hue = 180 * (Math.atan2(b, a) / Math.PI);
 
   return {
     l: laba.l,
-    c: Math.sqrt(laba.a * laba.a + laba.b * laba.b),
+    c: Math.sqrt(a * a + b * b),
     h: hue < 0 ? hue + 360 : hue,
     a: laba.alpha,
   };

--- a/src/colorModels/xyz.ts
+++ b/src/colorModels/xyz.ts
@@ -3,20 +3,20 @@ import { clamp, isPresent, round } from "../helpers";
 import { clampRgba, linearizeRgbChannel, unlinearizeRgbChannel } from "./rgb";
 
 /**
- * Limits XYZ axis values.
+ * Limits XYZ axis values assuming XYZ is relative to D50.
  * https://www.sttmedia.com/colormodel-xyz
  */
 export const clampXyza = (xyza: XyzaColor): XyzaColor => ({
-  x: clamp(xyza.x, 0, 95.047),
+  x: clamp(xyza.x, 0, 96.42),
   y: clamp(xyza.y, 0, 100),
-  z: clamp(xyza.z, 0, 108.883),
+  z: clamp(xyza.z, 0, 82.52),
   a: clamp(xyza.a),
 });
 
 export const roundXyza = (xyza: XyzaColor): XyzaColor => ({
-  x: round(xyza.x, 3),
-  y: round(xyza.y, 3),
-  z: round(xyza.z, 3),
+  x: round(xyza.x, 2),
+  y: round(xyza.y, 2),
+  z: round(xyza.z, 2),
   a: round(xyza.a, 2),
 });
 
@@ -34,10 +34,31 @@ export const parseXyza = ({ x, y, z, a = 1 }: InputObject): RgbaColor | null => 
 };
 
 /**
- * Converts an CIE XYZ color to RGBA color space
+ * Performs Bradford chromatic adaptation from D65 to D50
+ */
+export const adaptXyzaToD50 = (xyza: XyzaColor): XyzaColor => ({
+  x: xyza.x * 1.0478112 + xyza.y * 0.0228866 + xyza.z * -0.050127,
+  y: xyza.x * 0.0295424 + xyza.y * 0.9904844 + xyza.z * -0.0170491,
+  z: xyza.x * -0.0092345 + xyza.y * 0.0150436 + xyza.z * 0.7521316,
+  a: xyza.a,
+});
+
+/**
+ * Performs Bradford chromatic adaptation from D50 to D65
+ */
+export const adaptXyzaToD65 = (xyza: XyzaColor): XyzaColor => ({
+  x: xyza.x * 0.9555766 + xyza.y * -0.0230393 + xyza.z * 0.0631636,
+  y: xyza.x * -0.0282895 + xyza.y * 1.0099416 + xyza.z * 0.0210077,
+  z: xyza.x * 0.0122982 + xyza.y * -0.020483 + xyza.z * 1.3299098,
+  a: xyza.a,
+});
+
+/**
+ * Converts an CIE XYZ color (D50) to RGBA color space (D65)
  * https://www.w3.org/TR/css-color-4/#color-conversion-code
  */
-export const xyzaToRgba = (xyza: XyzaColor): RgbaColor => {
+export const xyzaToRgba = (sourceXyza: XyzaColor): RgbaColor => {
+  const xyza = adaptXyzaToD65(sourceXyza);
   const x = xyza.x / 100;
   const y = xyza.y / 100;
   const z = xyza.z / 100;
@@ -51,7 +72,7 @@ export const xyzaToRgba = (xyza: XyzaColor): RgbaColor => {
 };
 
 /**
- * Converts an RGBA color to CIE XYZ
+ * Converts an RGB color (D65) to CIE XYZ (D50)
  * https://image-engineering.de/library/technotes/958-how-to-convert-between-srgb-and-ciexyz
  */
 export const rgbaToXyza = (rgba: RgbaColor): XyzaColor => {
@@ -59,10 +80,14 @@ export const rgbaToXyza = (rgba: RgbaColor): XyzaColor => {
   const sGreen = linearizeRgbChannel(rgba.g);
   const sBlue = linearizeRgbChannel(rgba.b);
 
-  return clampXyza({
+  // Convert an array of linear-light sRGB values to CIE XYZ
+  // using sRGB own white (D65 no chromatic adaptation)
+  const xyza: XyzaColor = {
     x: (sRed * 0.4124564 + sGreen * 0.3575761 + sBlue * 0.1804375) * 100,
     y: (sRed * 0.2126729 + sGreen * 0.7151522 + sBlue * 0.072175) * 100,
     z: (sRed * 0.0193339 + sGreen * 0.119192 + sBlue * 0.9503041) * 100,
     a: rgba.a,
-  });
+  };
+
+  return clampXyza(adaptXyzaToD50(xyza));
 };

--- a/src/colorModels/xyz.ts
+++ b/src/colorModels/xyz.ts
@@ -2,14 +2,22 @@ import { InputObject, RgbaColor, XyzaColor } from "../types";
 import { clamp, isPresent, round } from "../helpers";
 import { clampRgba, linearizeRgbChannel, unlinearizeRgbChannel } from "./rgb";
 
+// Theoretical light source that approximates "warm daylight" and follows the CIE standard.
+// https://en.wikipedia.org/wiki/Standard_illuminant
+export const D50 = {
+  x: 96.422,
+  y: 100,
+  z: 82.521,
+};
+
 /**
  * Limits XYZ axis values assuming XYZ is relative to D50.
  * https://www.sttmedia.com/colormodel-xyz
  */
 export const clampXyza = (xyza: XyzaColor): XyzaColor => ({
-  x: clamp(xyza.x, 0, 96.42),
-  y: clamp(xyza.y, 0, 100),
-  z: clamp(xyza.z, 0, 82.52),
+  x: clamp(xyza.x, 0, D50.x),
+  y: clamp(xyza.y, 0, D50.y),
+  z: clamp(xyza.z, 0, D50.z),
   a: clamp(xyza.a),
 });
 

--- a/src/plugins/mix.ts
+++ b/src/plugins/mix.ts
@@ -1,6 +1,6 @@
-import { AnyColor, LchaColor } from "../types";
+import { AnyColor, RgbaColor } from "../types";
 import { Plugin } from "../extend";
-import { rgbaToLcha } from "../colorModels/lch";
+import { lchaToRgba, rgbaToLcha } from "../colorModels/lch";
 
 declare module "../colord" {
   interface Colord {
@@ -26,12 +26,12 @@ const mixPlugin: Plugin = (ColordClass): void => {
     const lcha1 = rgbaToLcha(this.toRgb());
     const lcha2 = rgbaToLcha(instance2.toRgb());
 
-    const mixture: LchaColor = {
+    const mixture: RgbaColor = lchaToRgba({
       l: lcha1.l * (1 - ratio) + lcha2.l * ratio,
       c: lcha1.c * (1 - ratio) + lcha2.c * ratio,
       h: lcha1.h * (1 - ratio) + lcha2.h * ratio,
       a: lcha1.a * (1 - ratio) + lcha2.a * ratio,
-    };
+    });
 
     return new ColordClass(mixture);
   };

--- a/src/plugins/mix.ts
+++ b/src/plugins/mix.ts
@@ -1,7 +1,6 @@
 import { AnyColor, LchaColor } from "../types";
 import { Plugin } from "../extend";
-import { rgbaToLcha, lchaToRgba } from "../colorModels/lch";
-import { rgbaToLchaString } from "../colorModels/lchString";
+import { rgbaToLcha } from "../colorModels/lch";
 
 declare module "../colord" {
   interface Colord {
@@ -9,8 +8,7 @@ declare module "../colord" {
      * Produces a mixture of two colors through LCH color space.
      * Returns the result (a new Colord instance) of mixing them.
      * The logic is ported from new `color-mix` function in CSS.
-     * https://www.w3.org/TR/css-color-5/#colormix
-     * https://drafts.csswg.org/css-color-5/#color-mix
+     * https://drafts.csswg.org/css-color-5/#funcdef-color-mix
      */
     mix(color2: AnyColor | Colord, ratio?: number): Colord;
   }
@@ -28,11 +26,6 @@ const mixPlugin: Plugin = (ColordClass): void => {
     const lcha1 = rgbaToLcha(this.toRgb());
     const lcha2 = rgbaToLcha(instance2.toRgb());
 
-    // console.log(`
-    //   background-color: ${this.toHex()};
-    //   background-color: ${rgbaToLchaString(this.toRgb())};
-    // `);
-
     const mixture: LchaColor = {
       l: lcha1.l * (1 - ratio) + lcha2.l * ratio,
       c: lcha1.c * (1 - ratio) + lcha2.c * ratio,
@@ -40,7 +33,7 @@ const mixPlugin: Plugin = (ColordClass): void => {
       a: lcha1.a * (1 - ratio) + lcha2.a * ratio,
     };
 
-    return new ColordClass(lchaToRgba(mixture));
+    return new ColordClass(mixture);
   };
 };
 

--- a/src/plugins/mix.ts
+++ b/src/plugins/mix.ts
@@ -15,7 +15,7 @@ declare module "../colord" {
 }
 
 /**
- * A plugin adding color a mixing utility.
+ * A plugin adding a color mixing utility.
  * The logic is ported from new `color-mix` function in CSS.
  * https://www.w3.org/TR/css-color-5/#colormix
  */

--- a/src/plugins/mix.ts
+++ b/src/plugins/mix.ts
@@ -1,0 +1,47 @@
+import { AnyColor, LchaColor } from "../types";
+import { Plugin } from "../extend";
+import { rgbaToLcha, lchaToRgba } from "../colorModels/lch";
+import { rgbaToLchaString } from "../colorModels/lchString";
+
+declare module "../colord" {
+  interface Colord {
+    /**
+     * Produces a mixture of two colors through LCH color space.
+     * Returns the result (a new Colord instance) of mixing them.
+     * The logic is ported from new `color-mix` function in CSS.
+     * https://www.w3.org/TR/css-color-5/#colormix
+     * https://drafts.csswg.org/css-color-5/#color-mix
+     */
+    mix(color2: AnyColor | Colord, ratio?: number): Colord;
+  }
+}
+
+/**
+ * A plugin adding color a mixing utility.
+ * The logic is ported from new `color-mix` function in CSS.
+ * https://www.w3.org/TR/css-color-5/#colormix
+ */
+const mixPlugin: Plugin = (ColordClass): void => {
+  ColordClass.prototype.mix = function (color2, ratio = 0.5) {
+    const instance2 = color2 instanceof ColordClass ? color2 : new ColordClass(color2);
+
+    const lcha1 = rgbaToLcha(this.toRgb());
+    const lcha2 = rgbaToLcha(instance2.toRgb());
+
+    // console.log(`
+    //   background-color: ${this.toHex()};
+    //   background-color: ${rgbaToLchaString(this.toRgb())};
+    // `);
+
+    const mixture: LchaColor = {
+      l: lcha1.l * (1 - ratio) + lcha2.l * ratio,
+      c: lcha1.c * (1 - ratio) + lcha2.c * ratio,
+      h: lcha1.h * (1 - ratio) + lcha2.h * ratio,
+      a: lcha1.a * (1 - ratio) + lcha2.a * ratio,
+    };
+
+    return new ColordClass(lchaToRgba(mixture));
+  };
+};
+
+export default mixPlugin;

--- a/tests/plugins.test.ts
+++ b/tests/plugins.test.ts
@@ -77,7 +77,7 @@ describe("lab", () => {
   extend([labPlugin]);
 
   it("Parses CIE LAB color object", () => {
-    // https://www.easyrgb.com/en/convert.php
+    // https://cielab.xyz/colorconv/
     expect(colord({ l: 100, a: 0, b: 0 }).toHex()).toBe("#ffffff");
     expect(colord({ l: 0, a: 0, b: 0 }).toHex()).toBe("#000000");
     expect(colord({ l: 54.29, a: 80.81, b: 69.89 }).toHex()).toBe("#ff0000");
@@ -86,7 +86,7 @@ describe("lab", () => {
   });
 
   it("Converts a color to CIE LAB object", () => {
-    // https://www.easyrgb.com/en/convert.php
+    // https://cielab.xyz/colorconv/
     expect(colord("#ffffff").toLab()).toMatchObject({ l: 100, a: 0, b: 0, alpha: 1 });
     expect(colord("#00000000").toLab()).toMatchObject({ l: 0, a: 0, b: 0, alpha: 0 });
     expect(colord("#ff0000").toLab()).toMatchObject({ l: 54.29, a: 80.81, b: 69.89, alpha: 1 });
@@ -102,51 +102,62 @@ describe("lch", () => {
   extend([lchPlugin]);
 
   it("Parses CIE LCH color object", () => {
-    // http://colormine.org/convert/rgb-to-lch
-    // https://css.land/lch/
-    // https://drafts.csswg.org/css-color-5/#relative-LCH
+    // https://www.w3.org/TR/css-color-4/#specifying-lab-lch
     expect(colord({ l: 0, c: 0, h: 0, a: 0 }).toHex()).toBe("#00000000");
     expect(colord({ l: 100, c: 0, h: 0 }).toHex()).toBe("#ffffff");
-    expect(colord({ l: 42.37, c: 0, h: 0 }).toHex()).toBe("#646464");
-    expect(colord({ l: 48.25, c: 30.07, h: 196.38 }).toHex()).toBe("#008080");
-    expect(colord({ l: 51.87, c: 58.13, h: 102.85 }).toHex()).toBe("#808000");
-    expect(colord({ l: 21.85, c: 31.95, h: 127.77 }).toHex()).toBe("#213b0b");
+    expect(colord({ l: 29.2345, c: 44.2, h: 27 }).toHex()).toBe("#7d2329");
+    expect(colord({ l: 52.2345, c: 72.2, h: 56.2 }).toHex()).toBe("#c65d06");
+    expect(colord({ l: 60.2345, c: 59.2, h: 95.2 }).toHex()).toBe("#9d9318");
+    expect(colord({ l: 62.2345, c: 59.2, h: 126.2 }).toHex()).toBe("#68a639");
+    expect(colord({ l: 67.5345, c: 42.5, h: 258.2, a: 0.5 }).toHex()).toBe("#62acef80");
   });
 
   it("Parses CIE LCH color string", () => {
+    // https://cielab.xyz/colorconv/
+    // https://www.w3.org/TR/css-color-4/
     expect(colord("lch(0% 0 0 / 0)").toHex()).toBe("#00000000");
     expect(colord("lch(100% 0 0)").toHex()).toBe("#ffffff");
-    expect(colord("lch(42.37, 0, 0, 0.5").toHex()).toBe("#64646480");
-    expect(colord("lch(51.87% 58.13 102.85 / 50%").toHex()).toBe("#80800080");
-    expect(colord("  lch(   48.25   30.07,196.38   /    0.5000").toHex()).toBe("#00808080");
+    expect(colord("lch(52.2345% 72.2 56.2 / 1)").toHex()).toBe("#c65d06");
+    expect(colord("lch(37% 105 305)").toHex()).toBe("#6a27e7");
+    expect(colord("lch(56.2% 83.6 357.4 / 93%)").toHex()).toBe("#fe1091ed");
   });
 
   it("Converts a color to CIE LCH object", () => {
-    // http://colormine.org/convert/rgb-to-lch
-    expect(colord("#00000080").toLch()).toMatchObject({ l: 0, c: 0, h: 0, a: 0.5 });
-    expect(colord("#ffffff").toLch()).toMatchObject({ l: 100, c: 0, h: 0 });
-    expect(colord("#008080").toLch()).toMatchObject({ l: 48.25, c: 30.07, h: 196.38 });
-    expect(colord("#808000").toLch()).toMatchObject({ l: 51.87, c: 58.13, h: 102.85 });
-    expect(colord("#213b0b").toLch()).toMatchObject({ l: 21.85, c: 31.95, h: 127.77 });
-    expect(colord("#646464").toLch()).toMatchObject({ l: 42.37, c: 0, h: 158.2 });
+    // https://cielab.xyz/colorconv/
+    expect(colord("#00000000").toLch()).toMatchObject({ l: 0, c: 0, h: 0, a: 0 });
+    expect(colord("#ffffff").toLch()).toMatchObject({ l: 100, c: 0, h: 0, a: 1 });
+    expect(colord("#7d2329").toLch()).toMatchObject({ l: 29.16, c: 44.14, h: 26.48, a: 1 });
+    expect(colord("#c65d06").toLch()).toMatchObject({ l: 52.31, c: 72.21, h: 56.33, a: 1 });
+    expect(colord("#9d9318").toLch()).toMatchObject({ l: 60.31, c: 59.2, h: 95.46, a: 1 });
+    expect(colord("#68a639").toLch()).toMatchObject({ l: 62.22, c: 59.15, h: 126.15, a: 1 });
+    expect(colord("#62acef80").toLch()).toMatchObject({ l: 67.67, c: 42.18, h: 257.79, a: 0.5 });
   });
 
   it("Converts a color to CIE LCH string (CSS functional notation)", () => {
+    // https://cielab.xyz/colorconv/
     expect(colord("#00000080").toLchString()).toBe("lch(0% 0 0 / 0.5)");
     expect(colord("#ffffff").toLchString()).toBe("lch(100% 0 0)");
-    expect(colord("#00808000").toLchString()).toBe("lch(48.25% 30.07 196.38 / 0)");
+    expect(colord("#c65d06ed").toLchString()).toBe("lch(52.31% 72.21 56.33 / 0.93)");
+    expect(colord("#aabbcc").toLchString()).toBe("lch(74.97% 11.22 252.37)");
   });
 });
 
-// describe("mix", () => {
-//   extend([mixPlugin]);
+describe("mix", () => {
+  extend([mixPlugin]);
 
-//   it("Mixes two colors", () => {
-//     expect(colord("#00F").mix("#FF0").toHex()).toBe("#00c6f1");
-//     expect(colord("#F00").mix("#FF0", 0.35).toHex()).toBe("#ff7f00");
-//     expect(colord("#cd853f").mix("#fcfaee", 0.6).toHex()).toBe("#e3cea2");
-//   });
-// });
+  it("Mixes two colors", () => {
+    // https://drafts.csswg.org/css-color-5/#funcdef-color-mix
+    expect(colord("#800080").mix("#dda0dd").toHex()).toBe("#af5cae");
+    expect(colord("#cd853f").mix("#eee8aa", 0.6).toHex()).toBe("#dfc279");
+    expect(colord("#008080").mix("#808000", 0.35).toHex()).toBe("#14865f");
+  });
+
+  it("Return the color if both values are equal", () => {
+    // https://drafts.csswg.org/css-color-5/#funcdef-color-mix
+    expect(colord("#ffffff").mix("#ffffff").toHex()).toBe("#ffffff");
+    expect(colord("#000000").mix("#000000").toHex()).toBe("#000000");
+  });
+});
 
 describe("names", () => {
   extend([namesPlugin]);
@@ -192,6 +203,7 @@ describe("xyz", () => {
 
   it("Converts a color to CIE XYZ object", () => {
     // https://www.easyrgb.com/en/convert.php
+    // https://cielab.xyz/colorconv/
     expect(colord("#ffffff").toXyz()).toMatchObject({ x: 96.42, y: 100, z: 82.52, a: 1 });
     expect(colord("#5cbf54").toXyz()).toMatchObject({ x: 26, y: 40.27, z: 11.54, a: 1 });
     expect(colord("#00000000").toXyz()).toMatchObject({ x: 0, y: 0, z: 0, a: 0 });

--- a/tests/plugins.test.ts
+++ b/tests/plugins.test.ts
@@ -3,6 +3,7 @@ import a11yPlugin from "../src/plugins/a11y";
 import hwbPlugin from "../src/plugins/hwb";
 import labPlugin from "../src/plugins/lab";
 import lchPlugin from "../src/plugins/lch";
+import mixPlugin from "../src/plugins/mix";
 import namesPlugin from "../src/plugins/names";
 import xyzPlugin from "../src/plugins/xyz";
 
@@ -79,21 +80,21 @@ describe("lab", () => {
     // https://www.easyrgb.com/en/convert.php
     expect(colord({ l: 100, a: 0, b: 0 }).toHex()).toBe("#ffffff");
     expect(colord({ l: 0, a: 0, b: 0 }).toHex()).toBe("#000000");
-    expect(colord({ l: 53.24, a: 80.09, b: 67.2 }).toHex()).toBe("#ff0000");
-    expect(colord({ l: 14.89, a: 5.77, b: 14.41, alpha: 0.5 }).toHex()).toBe("#33221180");
-    expect(colord({ l: 50.48, a: 65.85, b: -7.51, alpha: 1 }).toHex()).toBe("#d53987");
+    expect(colord({ l: 54.29, a: 80.81, b: 69.89 }).toHex()).toBe("#ff0000");
+    expect(colord({ l: 15.05, a: 6.68, b: 14.59, alpha: 0.5 }).toHex()).toBe("#33221180");
+    expect(colord({ l: 50.93, a: 64.96, b: -6.38, alpha: 1 }).toHex()).toBe("#d53987");
   });
 
   it("Converts a color to CIE LAB object", () => {
     // https://www.easyrgb.com/en/convert.php
     expect(colord("#ffffff").toLab()).toMatchObject({ l: 100, a: 0, b: 0, alpha: 1 });
     expect(colord("#00000000").toLab()).toMatchObject({ l: 0, a: 0, b: 0, alpha: 0 });
-    expect(colord("#ff0000").toLab()).toMatchObject({ l: 53.24, a: 80.09, b: 67.2, alpha: 1 });
-    expect(colord("#00ff00").toLab()).toMatchObject({ l: 87.73, a: -86.18, b: 83.18, alpha: 1 });
-    expect(colord("#ffff00").toLab()).toMatchObject({ l: 97.14, a: -21.55, b: 94.48, alpha: 1 });
-    expect(colord("#aabbcc").toLab()).toMatchObject({ l: 75.1, a: -2.29, b: -10.53, alpha: 1 });
-    expect(colord("#33221180").toLab()).toMatchObject({ l: 14.89, a: 5.77, b: 14.41, alpha: 0.5 });
-    expect(colord("#d53987").toLab()).toMatchObject({ l: 50.48, a: 65.85, b: -7.51, alpha: 1 });
+    expect(colord("#ff0000").toLab()).toMatchObject({ l: 54.29, a: 80.81, b: 69.89, alpha: 1 });
+    expect(colord("#00ff00").toLab()).toMatchObject({ l: 87.82, a: -79.29, b: 80.99, alpha: 1 });
+    expect(colord("#ffff00").toLab()).toMatchObject({ l: 97.61, a: -15.75, b: 93.39, alpha: 1 });
+    expect(colord("#aabbcc").toLab()).toMatchObject({ l: 74.97, a: -3.4, b: -10.7, alpha: 1 });
+    expect(colord("#33221180").toLab()).toMatchObject({ l: 15.05, a: 6.68, b: 14.59, alpha: 0.5 });
+    expect(colord("#d53987").toLab()).toMatchObject({ l: 50.93, a: 64.96, b: -6.38, alpha: 1 });
   });
 });
 
@@ -137,6 +138,16 @@ describe("lch", () => {
   });
 });
 
+// describe("mix", () => {
+//   extend([mixPlugin]);
+
+//   it("Mixes two colors", () => {
+//     expect(colord("#00F").mix("#FF0").toHex()).toBe("#00c6f1");
+//     expect(colord("#F00").mix("#FF0", 0.35).toHex()).toBe("#ff7f00");
+//     expect(colord("#cd853f").mix("#fcfaee", 0.6).toHex()).toBe("#e3cea2");
+//   });
+// });
+
 describe("names", () => {
   extend([namesPlugin]);
 
@@ -175,14 +186,14 @@ describe("xyz", () => {
   it("Parses XYZ color object", () => {
     // https://www.nixsensor.com/free-color-converter/
     expect(colord({ x: 0, y: 0, z: 0 }).toHex()).toBe("#000000");
-    expect(colord({ x: 50, y: 50, z: 50 }).toHex()).toBe("#ccb7b4");
-    expect(colord({ x: 95.047, y: 100, z: 108.883, a: 1 }).toHex()).toBe("#ffffff");
+    expect(colord({ x: 50, y: 50, z: 50 }).toHex()).toBe("#beb9cf");
+    expect(colord({ x: 96.42, y: 100, z: 82.52, a: 1 }).toHex()).toBe("#ffffff");
   });
 
   it("Converts a color to CIE XYZ object", () => {
     // https://www.easyrgb.com/en/convert.php
-    expect(colord("#ffffff").toXyz()).toMatchObject({ x: 95.047, y: 100, z: 108.883, a: 1 });
-    expect(colord("#5cbf54").toXyz()).toMatchObject({ x: 24.643, y: 40.175, z: 14.842, a: 1 });
+    expect(colord("#ffffff").toXyz()).toMatchObject({ x: 96.42, y: 100, z: 82.52, a: 1 });
+    expect(colord("#5cbf54").toXyz()).toMatchObject({ x: 26, y: 40.27, z: 11.54, a: 1 });
     expect(colord("#00000000").toXyz()).toMatchObject({ x: 0, y: 0, z: 0, a: 0 });
   });
 });


### PR DESCRIPTION
New `mix` method to create a mixture of two colors in LCH color space (the same way it will be done in the new CSS `color-mix` function) 