### PR TITLE
Mix colors through CIE LAB color space

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 1.4.1
+
+- Mix colors through CIE LAB color space
+
 ### 1.4.0
 
 - New plugin: Color mixing

--- a/README.md
+++ b/README.md
@@ -383,7 +383,7 @@ colord("hsl(0, 50%, 100%)").lighten(0.5).toHslString(); // "hsl(0, 50%, 50%)"
 
 Produces a mixture of two colors and returns the result of mixing them (new Colord instance).
 
-In contrast to other libraries that perform RGB values mixing, Colord mixes colors through LCH color space — same way the new CSS [`color-mix` function](https://drafts.csswg.org/css-color-5/#funcdef-color-mix) works. This approach produces better results and doesn't have the drawbacks the legacy way has.
+In contrast to other libraries that perform RGB values mixing, Colord mixes colors through [LAB color space](https://en.wikipedia.org/wiki/CIELAB_color_space). This approach produces better results and doesn't have the drawbacks the legacy way has.
 
 ```js
 import { colord, extend } from "colord";
@@ -604,11 +604,11 @@ colord("#646464").alpha(0.5).toLchString(); // "lch(42.37% 0 0 / 0.5)"
 </details>
 
 <details>
-  <summary><b><code>mix</code> (Color mixing)</b> <i>0.97 KB</i></summary>
+  <summary><b><code>mix</code> (Color mixing)</b> <i>0.9 KB</i></summary>
 
 A plugin adding a color mixing utility.
 
-In contrast to other libraries that perform RGB values mixing, Colord mixes colors through LCH color space — same way the new CSS [`color-mix` function](https://drafts.csswg.org/css-color-5/#funcdef-color-mix) works. This approach produces better results and doesn't have the drawbacks the legacy way has.
+In contrast to other libraries that perform RGB values mixing, Colord mixes colors through [LAB color space](https://en.wikipedia.org/wiki/CIELAB_color_space). This approach produces better results and doesn't have the drawbacks the legacy way has.
 
 ```js
 import { colord, extend } from "colord";

--- a/src/manipulate/mix.ts
+++ b/src/manipulate/mix.ts
@@ -1,0 +1,16 @@
+import { clampLaba, labaToRgba, rgbaToLaba } from "../colorModels/lab";
+import { RgbaColor } from "../types";
+
+export const mix = (rgba1: RgbaColor, rgba2: RgbaColor, ratio: number): RgbaColor => {
+  const laba1 = rgbaToLaba(rgba1);
+  const laba2 = rgbaToLaba(rgba2);
+
+  const mixture = clampLaba({
+    l: laba1.l * (1 - ratio) + laba2.l * ratio,
+    a: laba1.a * (1 - ratio) + laba2.a * ratio,
+    b: laba1.b * (1 - ratio) + laba2.b * ratio,
+    alpha: laba1.alpha * (1 - ratio) + laba2.alpha * ratio,
+  });
+
+  return labaToRgba(mixture);
+};

--- a/src/plugins/mix.ts
+++ b/src/plugins/mix.ts
@@ -1,14 +1,11 @@
-import { AnyColor, RgbaColor } from "../types";
+import { AnyColor } from "../types";
 import { Plugin } from "../extend";
-import { lchaToRgba, rgbaToLcha } from "../colorModels/lch";
+import { mix } from "../manipulate/mix";
 
 declare module "../colord" {
   interface Colord {
     /**
-     * Produces a mixture of two colors through LCH color space.
-     * Returns the result (a new Colord instance) of mixing them.
-     * The logic is ported from new `color-mix` function in CSS.
-     * https://drafts.csswg.org/css-color-5/#funcdef-color-mix
+     * Produces a mixture of two colors through CIE LAB color space and returns a new Colord instance.
      */
     mix(color2: AnyColor | Colord, ratio?: number): Colord;
   }
@@ -16,23 +13,12 @@ declare module "../colord" {
 
 /**
  * A plugin adding a color mixing utility.
- * The logic is ported from new `color-mix` function in CSS.
- * https://www.w3.org/TR/css-color-5/#colormix
  */
 const mixPlugin: Plugin = (ColordClass): void => {
   ColordClass.prototype.mix = function (color2, ratio = 0.5) {
     const instance2 = color2 instanceof ColordClass ? color2 : new ColordClass(color2);
 
-    const lcha1 = rgbaToLcha(this.toRgb());
-    const lcha2 = rgbaToLcha(instance2.toRgb());
-
-    const mixture: RgbaColor = lchaToRgba({
-      l: lcha1.l * (1 - ratio) + lcha2.l * ratio,
-      c: lcha1.c * (1 - ratio) + lcha2.c * ratio,
-      h: lcha1.h * (1 - ratio) + lcha2.h * ratio,
-      a: lcha1.a * (1 - ratio) + lcha2.a * ratio,
-    });
-
+    const mixture = mix(this.toRgb(), instance2.toRgb(), ratio);
     return new ColordClass(mixture);
   };
 };

--- a/tests/plugins.test.ts
+++ b/tests/plugins.test.ts
@@ -146,14 +146,20 @@ describe("mix", () => {
   extend([mixPlugin]);
 
   it("Mixes two colors", () => {
-    // https://drafts.csswg.org/css-color-5/#funcdef-color-mix
+    expect(colord("#000000").mix("#ffffff").toHex()).toBe("#777777");
+    expect(colord("#dc143c").mix("#000000").toHex()).toBe("#6a1b21");
     expect(colord("#800080").mix("#dda0dd").toHex()).toBe("#af5cae");
-    expect(colord("#cd853f").mix("#eee8aa", 0.6).toHex()).toBe("#dfc279");
-    expect(colord("#008080").mix("#808000", 0.35).toHex()).toBe("#14865f");
+    expect(colord("#228b22").mix("#87cefa").toHex()).toBe("#60ac8f");
+    expect(colord("#cd853f").mix("#eee8aa", 0.6).toHex()).toBe("#e3c07e");
+    expect(colord("#483d8b").mix("#00bfff", 0.35).toHex()).toBe("#4969b2");
+  });
+
+  it("Returns the same color if ratio is 0 or 1", () => {
+    expect(colord("#cd853f").mix("#ffffff", 0).toHex()).toBe("#cd853f");
+    expect(colord("#ffffff").mix("#cd853f", 1).toHex()).toBe("#cd853f");
   });
 
   it("Return the color if both values are equal", () => {
-    // https://drafts.csswg.org/css-color-5/#funcdef-color-mix
     expect(colord("#ffffff").mix("#ffffff").toHex()).toBe("#ffffff");
     expect(colord("#000000").mix("#000000").toHex()).toBe("#000000");
   });


### PR DESCRIPTION
I was trying to mimic the CSS drafts in the previous version, but produced mixtures look weird since the hue interpolation logic, so I switched the space for mixing to CIE LAB which produces better results.