### PR TITLE
Random color generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -513,6 +513,22 @@ colord("#e60000").isReadable("#ffff47", { level: "AAA", size: "large" }); // tru
 
 </details>
 
+### Color utilities
+
+<details>
+  <summary><b><code>random()</code></b></summary>
+
+Returns a new Colord instance with a random color value inside.
+
+```js
+import { random } from "colord";
+
+random().toHex(); // "#01c8ec"
+random().alpha(0.5).toRgb(); // { r: 13, g: 237, b: 162, a: 0.5 }
+```
+
+</details>
+
 <div><img src="assets/divider.png" width="838" alt="---" /></div>
 
 ## Plugins

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 export { colord, Colord } from "./colord";
 export { extend, Plugin } from "./extend";
+export { random } from "./random";
 
 export {
   HslColor,

--- a/src/random.ts
+++ b/src/random.ts
@@ -1,0 +1,9 @@
+import { Colord } from "./colord";
+
+export const random = (): Colord => {
+  return new Colord({
+    r: Math.random() * 255,
+    g: Math.random() * 255,
+    b: Math.random() * 255,
+  });
+};

--- a/tests/colord.test.ts
+++ b/tests/colord.test.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment */
-import { colord, AnyColor } from "../src/";
+import { colord, random, Colord, AnyColor } from "../src/";
 import { fixtures, lime, saturationLevels } from "./fixtures";
 
 it("Converts between HEX, RGB, HSL and HSV color models properly", () => {
@@ -200,4 +200,9 @@ it("Gets an alpha channel value", () => {
 it("Changes an alpha channel value", () => {
   expect(colord("#000").alpha(0.25).alpha()).toBe(0.25);
   expect(colord("#FFF").alpha(0).toRgb().a).toBe(0);
+});
+
+it("Generates a random color", () => {
+  expect(random()).toBeInstanceOf(Colord);
+  expect(random().toHex()).not.toBe(random().toHex());
 });


### PR DESCRIPTION
Many GH projects use random colors for their purposes, so it makes sense for us to add this tiny API.

In contrast to other libraries, our `random` is tree-shakeable.