### PR TITLE
New `getFormat` function

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ colord({ r: NaN, g: -Infinity, b: +Infinity, a: 100500 }).toRgb(); // { r: 0, g:
 ### Color conversion
 
 <details>
-  <summary><b><code>toHex()</code></b></summary>
+  <summary><b><code>.toHex()</code></b></summary>
 
 Returns the [hexadecimal representation](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value#rgb_colors) of a color. When the alpha channel value of the color is less than 1, it outputs `#rrggbbaa` format instead of `#rrggbb`.
 
@@ -133,7 +133,7 @@ colord({ r: 255, g: 255, b: 255, a: 0 }).toHex(); // "#ffffff00"
 </details>
 
 <details>
-  <summary><b><code>toRgb()</code></b></summary>
+  <summary><b><code>.toRgb()</code></b></summary>
 
 ```js
 colord("#ff0000").toRgb(); // { r: 255, g: 0, b: 0, a: 1 }
@@ -143,7 +143,7 @@ colord({ h: 180, s: 100, l: 50, a: 0.5 }).toRgb(); // { r: 0, g: 255, b: 255, a:
 </details>
 
 <details>
-  <summary><b><code>toRgbString()</code></b></summary>
+  <summary><b><code>.toRgbString()</code></b></summary>
 
 ```js
 colord("#ff0000").toRgbString(); // "rgb(255, 0, 0)"
@@ -153,7 +153,7 @@ colord({ h: 180, s: 100, l: 50, a: 0.5 }).toRgbString(); // "rgba(0, 255, 255, 0
 </details>
 
 <details>
-  <summary><b><code>toHsl()</code></b></summary>
+  <summary><b><code>.toHsl()</code></b></summary>
 
 Converts a color to [HSL color space](https://en.wikipedia.org/wiki/HSL_and_HSV) and returns an object.
 
@@ -165,7 +165,7 @@ colord("rgba(0, 0, 255, 0.5) ").toHsl(); // { h: 240, s: 100, l: 50, a: 0.5 }
 </details>
 
 <details>
-  <summary><b><code>toHslString()</code></b></summary>
+  <summary><b><code>.toHslString()</code></b></summary>
 
 Converts a color to [HSL color space](https://en.wikipedia.org/wiki/HSL_and_HSV) and expresses it through the [functional notation](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value#hsl_colors).
 
@@ -177,7 +177,7 @@ colord("rgba(0, 0, 255, 0.5)").toHslString(); // "hsla(240, 100%, 50%, 0.5)"
 </details>
 
 <details>
-  <summary><b><code>toHsv()</code></b></summary>
+  <summary><b><code>.toHsv()</code></b></summary>
 
 Converts a color to [HSV color space](https://en.wikipedia.org/wiki/HSL_and_HSV) and returns an object.
 
@@ -189,7 +189,7 @@ colord("rgba(0, 255, 255, 0.5) ").toHsv(); // { h: 180, s: 100, v: 100, a: 1 }
 </details>
 
 <details>
-  <summary><b><code>toName()</code></b> (<b>names</b> plugin)</summary>
+  <summary><b><code>.toName()</code></b> (<b>names</b> plugin)</summary>
 
 Converts a color to a [CSS keyword](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value#color_keywords). Returns `undefined` if the color is not specified in the specs.
 
@@ -208,7 +208,7 @@ colord("rgba(0, 0, 0, 0)").toName(); // "transparent"
 </details>
 
 <details>
-  <summary><b><code>toHwb()</code></b> (<b>hwb</b> plugin)</summary>
+  <summary><b><code>.toHwb()</code></b> (<b>hwb</b> plugin)</summary>
 
 Converts a color to [HWB (Hue-Whiteness-Blackness)](https://en.wikipedia.org/wiki/HWB_color_model) color space.
 
@@ -225,7 +225,7 @@ colord("#555aaa").toHwb(); // { h: 236, w: 33, b: 33, a: 1 }
 </details>
 
 <details>
-  <summary><b><code>toHwbString()</code></b> (<b>hwb</b> plugin)</summary>
+  <summary><b><code>.toHwbString()</code></b> (<b>hwb</b> plugin)</summary>
 
 Converts a color to [HWB (Hue-Whiteness-Blackness)](https://en.wikipedia.org/wiki/HWB_color_model) color space and expresses it through the [functional notation](https://www.w3.org/TR/css-color-4/#the-hwb-notation).
 
@@ -243,7 +243,7 @@ colord("#003366").alpha(0.5).toHwbString(); // "hwb(210, 0%, 60%, 0.5)"
 </details>
 
 <details>
-  <summary><b><code>toLab()</code></b> (<b>lab</b> plugin)</summary>
+  <summary><b><code>.toLab()</code></b> (<b>lab</b> plugin)</summary>
 
 Converts a color to [CIE LAB](https://en.wikipedia.org/wiki/CIELAB_color_space) color space. The conversion logic is ported from [CSS Color Module Level 4 Specification](https://www.w3.org/TR/css-color-4/#color-conversion-code).
 
@@ -260,7 +260,7 @@ colord("#33221180").toLab(); // { l: 14.89, a: 5.77, b: 14.41, alpha: 0.5 }
 </details>
 
 <details>
-  <summary><b><code>toLch()</code></b> (<b>lch</b> plugin)</summary>
+  <summary><b><code>.toLch()</code></b> (<b>lch</b> plugin)</summary>
 
 Converts a color to [CIE LCH](https://lea.verou.me/2020/04/lch-colors-in-css-what-why-and-how/) color space. The conversion logic is ported from [CSS Color Module Level 4 Specification](https://www.w3.org/TR/css-color-4/#color-conversion-code).
 
@@ -277,7 +277,7 @@ colord("#213b0b").toLch(); // { l: 21.85, c: 31.95, h: 127.77, a: 1 }
 </details>
 
 <details>
-  <summary><b><code>toLchString()</code></b> (<b>lch</b> plugin)</summary>
+  <summary><b><code>.toLchString()</code></b> (<b>lch</b> plugin)</summary>
 
 Converts a color to [CIE LCH](https://lea.verou.me/2020/04/lch-colors-in-css-what-why-and-how/) color space and expresses it through the [functional notation](https://www.w3.org/TR/css-color-4/#specifying-lab-lch).
 
@@ -294,7 +294,7 @@ colord("#213b0b").alpha(0.5).toLchString(); // "lch(21.85% 31.95 127.77 / 0.5)"
 </details>
 
 <details>
-  <summary><b><code>toXyz()</code></b> (<b>xyz</b> plugin)</summary>
+  <summary><b><code>.toXyz()</code></b> (<b>xyz</b> plugin)</summary>
 
 Converts a color to [CIE XYZ](https://www.sttmedia.com/colormodel-xyz) color space. The conversion logic is ported from [CSS Color Module Level 4 Specification](https://www.w3.org/TR/css-color-4/#color-conversion-code).
 
@@ -312,7 +312,7 @@ colord("#ffffff").toXyz(); // { x: 95.047, y: 100, z: 108.883, a: 1 }
 ### Color manipulation
 
 <details>
-  <summary><b><code>alpha(value)</code></b></summary>
+  <summary><b><code>.alpha(value)</code></b></summary>
 
 Changes the alpha channel value and returns a new `Colord` instance.
 
@@ -323,7 +323,7 @@ colord("rgb(0, 0, 0)").alpha(0.5).toRgbString(); // rgba(0, 0, 0, 0.5)
 </details>
 
 <details>
-  <summary><b><code>invert()</code></b></summary>
+  <summary><b><code>.invert()</code></b></summary>
 
 Creates a new `Colord` instance containing an inverted (opposite) version of the color.
 
@@ -335,7 +335,7 @@ colord("#aabbcc").invert().toHex(); // "#554433"
 </details>
 
 <details>
-  <summary><b><code>saturate(amount = 0.1)</code></b></summary>
+  <summary><b><code>.saturate(amount = 0.1)</code></b></summary>
 
 Increases the [HSL saturation](https://en.wikipedia.org/wiki/HSL_and_HSV) of a color by the given amount.
 
@@ -347,7 +347,7 @@ colord("hsl(0, 50%, 50%)").saturate(0.5).toHslString(); // "hsl(0, 100%, 50%)"
 </details>
 
 <details>
-  <summary><b><code>desaturate(amount = 0.1)</code></b></summary>
+  <summary><b><code>.desaturate(amount = 0.1)</code></b></summary>
 
 Decreases the [HSL saturation](https://en.wikipedia.org/wiki/HSL_and_HSV) of a color by the given amount.
 
@@ -359,7 +359,7 @@ colord("hsl(0, 100%, 50%)").saturate(0.5).toHslString(); // "hsl(0, 50%, 50%)"
 </details>
 
 <details>
-  <summary><b><code>grayscale()</code></b></summary>
+  <summary><b><code>.grayscale()</code></b></summary>
 
 Makes a gray color with the same lightness as a source color. Same as calling `desaturate(1)`.
 
@@ -371,7 +371,7 @@ colord("hsl(0, 100%, 50%)").grayscale().toHslString(); // "hsl(0, 0%, 50%)"
 </details>
 
 <details>
-  <summary><b><code>lighten(amount = 0.1)</code></b></summary>
+  <summary><b><code>.lighten(amount = 0.1)</code></b></summary>
 
 Increases the [HSL lightness](https://en.wikipedia.org/wiki/HSL_and_HSV) of a color by the given amount.
 
@@ -384,7 +384,7 @@ colord("hsl(0, 50%, 50%)").lighten(0.5).toHslString(); // "hsl(0, 50%, 100%)"
 </details>
 
 <details>
-  <summary><b><code>darken(amount = 0.1)</code></b></summary>
+  <summary><b><code>.darken(amount = 0.1)</code></b></summary>
 
 Decreases the [HSL lightness](https://en.wikipedia.org/wiki/HSL_and_HSV) of a color by the given amount.
 
@@ -397,7 +397,7 @@ colord("hsl(0, 50%, 100%)").lighten(0.5).toHslString(); // "hsl(0, 50%, 50%)"
 </details>
 
 <details>
-  <summary><b><code>mix(color2, ratio = 0.5)</code></b> (<b>mix</b> plugin)</summary>
+  <summary><b><code>.mix(color2, ratio = 0.5)</code></b> (<b>mix</b> plugin)</summary>
 
 Produces a mixture of two colors and returns the result of mixing them (new Colord instance).
 
@@ -422,7 +422,7 @@ colord("#008080").mix("#808000", 0.35).toHex(); // "#50805d"
 ### Color analysis
 
 <details>
-  <summary><b><code>isValid()</code></b></summary>
+  <summary><b><code>.isValid()</code></b></summary>
 
 Returns a boolean indicating whether or not an input has been parsed successfully.
 Note: If parsing is unsuccessful, Colord defaults to black (does not throws an error).
@@ -438,7 +438,7 @@ colord({ r: 0, g: 0, v: 0 }).isValid(); // false
 </details>
 
 <details>
-  <summary><b><code>alpha()</code></b></summary>
+  <summary><b><code>.alpha()</code></b></summary>
 
 ```js
 colord("#ffffff").alpha(); // 1
@@ -448,7 +448,7 @@ colord("rgba(50, 100, 150, 0.5)").alpha(); // 0.5
 </details>
 
 <details>
-  <summary><b><code>brightness()</code></b></summary>
+  <summary><b><code>.brightness()</code></b></summary>
 
 Returns the brightness of a color (from 0 to 1). The calculation logic is modified from [Web Content Accessibility Guidelines](https://www.w3.org/TR/AERT/#color-contrast).
 
@@ -461,7 +461,7 @@ colord("#ffffff").brightness(); // 1
 </details>
 
 <details>
-  <summary><b><code>isLight()</code></b></summary>
+  <summary><b><code>.isLight()</code></b></summary>
 
 Same as calling `brightness() >= 0.5`.
 
@@ -474,7 +474,7 @@ colord("#ffffff").isLight(); // true
 </details>
 
 <details>
-  <summary><b><code>isDark()</code></b></summary>
+  <summary><b><code>.isDark()</code></b></summary>
 
 Same as calling `brightness() < 0.5`.
 
@@ -487,7 +487,7 @@ colord("#ffffff").isDark(); // false
 </details>
 
 <details>
-  <summary><b><code>luminance()</code></b> (<b>a11y</b> plugin)</summary>
+  <summary><b><code>.luminance()</code></b> (<b>a11y</b> plugin)</summary>
 
 Returns the relative luminance of a color, normalized to 0 for darkest black and 1 for lightest white as defined by [WCAG 2.0](https://www.w3.org/TR/WCAG20/#relativeluminancedef).
 
@@ -501,7 +501,7 @@ colord("#ffffff").luminance(); // 1
 </details>
 
 <details>
-  <summary><b><code>contrast(color2 = "#FFF")</code></b> (<b>a11y</b> plugin)</summary>
+  <summary><b><code>.contrast(color2 = "#FFF")</code></b> (<b>a11y</b> plugin)</summary>
 
 Calculates a contrast ratio for a color pair. This luminance difference is expressed as a ratio ranging from 1 (e.g. white on white) to 21 (e.g., black on a white). [WCAG Accessibility Level AA requires](https://webaim.org/articles/contrast/) a ratio of at least 4.5 for normal text and 3 for large text.
 
@@ -516,7 +516,7 @@ colord("#0000ff").contrast("#ff000"); // 2.14 (blue on red)
 </details>
 
 <details>
-  <summary><b><code>isReadable(color2 = "#FFF", options?)</code></b> (<b>a11y</b> plugin)</summary>
+  <summary><b><code>.isReadable(color2 = "#FFF", options?)</code></b> (<b>a11y</b> plugin)</summary>
 
 Checks that a background and text color pair is readable according to [WCAG 2.0 Contrast and Color Requirements](https://webaim.org/articles/contrast/).
 
@@ -543,6 +543,22 @@ import { random } from "colord";
 
 random().toHex(); // "#01c8ec"
 random().alpha(0.5).toRgb(); // { r: 13, g: 237, b: 162, a: 0.5 }
+```
+
+</details>
+
+<details>
+  <summary><b><code>getFormat(input)</code></b></summary>
+
+Returns a color model name for the input passed to the function.
+
+```js
+import { getFormat } from "colord";
+
+getFormat("#aabbcc"); // "hex"
+getFormat({ r: 13, g: 237, b: 162, a: 0.5 }); // "rgb"
+getFormat("hsl(180deg, 50%, 50%)"); // "hsl"
+getFormat("WUT?"); // undefined
 ```
 
 </details>

--- a/README.md
+++ b/README.md
@@ -70,11 +70,7 @@ colord("hsl(0deg, 50%, 50%)").darken(0.25).toHex(); // "#602020"
 
 <div><img src="assets/divider.png" width="838" alt="---" /></div>
 
-## API
-
-### Color parsing
-
-#### Accepted input formats
+## Supported Color Models
 
 - Hexadecimal strings (including 3, 4 and 8 digit notations)
 - RGB strings and objects
@@ -86,7 +82,20 @@ colord("hsl(0deg, 50%, 50%)").darken(0.25).toHex(); // "#602020"
 - LAB objects ([via plugin](#plugins))
 - XYZ objects ([via plugin](#plugins))
 
+<div><img src="assets/divider.png" width="838" alt="---" /></div>
+
+## API
+
+### Color parsing
+
+<details>
+  <summary><b><code>colord(input)</code></b></summary>
+
+Parses the given input and creates a new Colord instance.
+
 ```js
+import { colord } from "colord";
+
 // String input examples
 colord("FFF");
 colord("#ffffff");
@@ -106,6 +115,8 @@ colord({ h: 360, s: 100, v: 100 });
 colord({ h: 360, s: 100, v: 100, a: 1 });
 ```
 
+Check out the ["Plugins"](#plugins) section for more input format examples.
+
 #### Permissive parser
 
 The parser of the library is user-friendly: it trims unnecessary whitespaces, clamps numbers, disregards character case, punctuation, brackets, etc. Here are some examples:
@@ -116,6 +127,24 @@ colord("__rGbA 10 20,,  999...").toRgbString(); // "rgb(10, 20, 255)"
 colord(" hsL(  -10, 200% 30 .5!!!").toHslString(); // "hsla(350, 100%, 30%, 0.5)"
 colord({ r: NaN, g: -Infinity, b: +Infinity, a: 100500 }).toRgb(); // { r: 0, g: 0, b: 255, a: 1 }
 ```
+
+</details>
+
+<details>
+  <summary><b><code>getFormat(input)</code></b></summary>
+
+Returns a color model name for the input passed to the function. Uses the same parsing system as `colord` function.
+
+```js
+import { getFormat } from "colord";
+
+getFormat("#aabbcc"); // "hex"
+getFormat({ r: 13, g: 237, b: 162, a: 0.5 }); // "rgb"
+getFormat("hsl(180deg, 50%, 50%)"); // "hsl"
+getFormat("WUT?"); // undefined
+```
+
+</details>
 
 ### Color conversion
 
@@ -543,22 +572,6 @@ import { random } from "colord";
 
 random().toHex(); // "#01c8ec"
 random().alpha(0.5).toRgb(); // { r: 13, g: 237, b: 162, a: 0.5 }
-```
-
-</details>
-
-<details>
-  <summary><b><code>getFormat(input)</code></b></summary>
-
-Returns a color model name for the input passed to the function.
-
-```js
-import { getFormat } from "colord";
-
-getFormat("#aabbcc"); // "hex"
-getFormat({ r: 13, g: 237, b: 162, a: 0.5 }); // "rgb"
-getFormat("hsl(180deg, 50%, 50%)"); // "hsl"
-getFormat("WUT?"); // undefined
 ```
 
 </details>

--- a/src/colord.ts
+++ b/src/colord.ts
@@ -20,7 +20,7 @@ export class Colord {
   constructor(input: AnyColor) {
     // Internal color format is RGBA object.
     // We do not round the internal RGBA numbers for better conversion accuracy.
-    this.parsed = parse(input as Input);
+    this.parsed = parse(input as Input)[0];
     this.rgba = this.parsed || { r: 0, g: 0, b: 0, a: 1 };
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 export { colord, Colord } from "./colord";
 export { extend, Plugin } from "./extend";
+export { getFormat } from "./parse";
 export { random } from "./random";
 
 export {

--- a/src/plugins/hwb.ts
+++ b/src/plugins/hwb.ts
@@ -32,8 +32,8 @@ const hwbPlugin: Plugin = (ColordClass, parsers): void => {
     return rgbaToHwbaString(this.rgba);
   };
 
-  parsers.string.push(parseHwbaString);
-  parsers.object.push(parseHwba);
+  parsers.string.push([parseHwbaString, "hwb"]);
+  parsers.object.push([parseHwba, "hwb"]);
 };
 
 export default hwbPlugin;

--- a/src/plugins/lab.ts
+++ b/src/plugins/lab.ts
@@ -21,7 +21,7 @@ const labPlugin: Plugin = (ColordClass, parsers): void => {
     return roundLaba(rgbaToLaba(this.rgba));
   };
 
-  parsers.object.push(parseLaba);
+  parsers.object.push([parseLaba, "lab"]);
 };
 
 export default labPlugin;

--- a/src/plugins/lch.ts
+++ b/src/plugins/lch.ts
@@ -33,8 +33,8 @@ const lchPlugin: Plugin = (ColordClass, parsers): void => {
     return rgbaToLchaString(this.rgba);
   };
 
-  parsers.string.push(parseLchaString);
-  parsers.object.push(parseLcha);
+  parsers.string.push([parseLchaString, "lch"]);
+  parsers.object.push([parseLcha, "lch"]);
 };
 
 export default lchPlugin;

--- a/src/plugins/names.ts
+++ b/src/plugins/names.ts
@@ -1,4 +1,4 @@
-import { Parser, RgbaColor } from "../types";
+import { ParseFunction, RgbaColor } from "../types";
 import { Plugin } from "../extend";
 
 declare module "../colord" {
@@ -179,14 +179,14 @@ const namesPlugin: Plugin = (ColordClass, parsers): void => {
   };
 
   // Add CSS color names parser.
-  const parseColorName: Parser<string> = (input: string): RgbaColor | null => {
+  const parseColorName: ParseFunction<string> = (input: string): RgbaColor | null => {
     const name = input.trim();
     const hex = name === "transparent" ? "#0000" : NAME_HEX_STORE[name];
     if (hex) return new ColordClass(hex).toRgb();
     return null;
   };
 
-  parsers.string.push(parseColorName);
+  parsers.string.push([parseColorName, "name"]);
 };
 
 export default namesPlugin;

--- a/src/plugins/xyz.ts
+++ b/src/plugins/xyz.ts
@@ -18,7 +18,7 @@ const xyzPlugin: Plugin = (ColordClass, parsers): void => {
     return roundXyza(rgbaToXyza(this.rgba));
   };
 
-  parsers.object.push(parseXyza);
+  parsers.object.push([parseXyza, "xyz"]);
 };
 
 export default xyzPlugin;

--- a/src/types.ts
+++ b/src/types.ts
@@ -69,9 +69,15 @@ export type AnyColor = string | ObjectColor;
 
 export type InputObject = Record<string, unknown>;
 
+export type Format = "name" | "hex" | "rgb" | "hsl" | "hsv" | "hwb" | "xyz" | "lab" | "lch";
+
 export type Input = string | InputObject;
 
-export type Parser<I extends Input> = (input: I) => RgbaColor | null;
+export type ParseResult = [RgbaColor, Format];
+
+export type ParseFunction<I extends Input> = (input: I) => RgbaColor | null;
+
+export type Parser<I extends Input> = [ParseFunction<I>, Format];
 
 export type Parsers = {
   string: Array<Parser<string>>;

--- a/tests/colord.test.ts
+++ b/tests/colord.test.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment */
-import { colord, random, Colord, AnyColor } from "../src/";
+import { colord, random, getFormat, Colord, AnyColor } from "../src/";
 import { fixtures, lime, saturationLevels } from "./fixtures";
 
 it("Converts between HEX, RGB, HSL and HSV color models properly", () => {
@@ -225,4 +225,16 @@ it("Changes an alpha channel value", () => {
 it("Generates a random color", () => {
   expect(random()).toBeInstanceOf(Colord);
   expect(random().toHex()).not.toBe(random().toHex());
+});
+
+it("Gets an input color format", () => {
+  expect(getFormat("#000")).toBe("hex");
+  expect(getFormat("rgb(128, 128, 128)")).toBe("rgb");
+  expect(getFormat("hsl(180, 50, 50)")).toBe("hsl");
+  expect(getFormat({ r: 128, g: 128, b: 128, a: 0.5 })).toBe("rgb");
+  expect(getFormat({ h: 180, s: 50, l: 50, a: 0.5 })).toBe("hsl");
+  expect(getFormat({ h: 180, s: 50, v: 50, a: 0.5 })).toBe("hsv");
+  expect(getFormat("disco-dancing")).toBeUndefined();
+  // @ts-ignore
+  expect(getFormat({ w: 1, u: 2, t: 3 })).toBeUndefined();
 });

--- a/tests/plugins.test.ts
+++ b/tests/plugins.test.ts
@@ -1,4 +1,4 @@
-import { colord, extend } from "../src/";
+import { colord, getFormat, extend } from "../src/";
 import a11yPlugin from "../src/plugins/a11y";
 import hwbPlugin from "../src/plugins/hwb";
 import labPlugin from "../src/plugins/lab";
@@ -95,6 +95,11 @@ describe("hwb", () => {
     expect(colord("hwb(1.25turn 20% 20%)").toHwb().h).toBe(90);
     expect(colord("hwb(1.5708rad 20% 20%)").toHwb().h).toBe(90);
   });
+
+  it("Supported by `getFormat`", () => {
+    expect(getFormat("hwb(180deg 50% 50%)")).toBe("hwb");
+    expect(getFormat({ h: 0, w: 0, b: 100 })).toBe("hwb");
+  });
 });
 
 describe("lab", () => {
@@ -119,6 +124,10 @@ describe("lab", () => {
     expect(colord("#aabbcc").toLab()).toMatchObject({ l: 74.97, a: -3.4, b: -10.7, alpha: 1 });
     expect(colord("#33221180").toLab()).toMatchObject({ l: 15.05, a: 6.68, b: 14.59, alpha: 0.5 });
     expect(colord("#d53987").toLab()).toMatchObject({ l: 50.93, a: 64.96, b: -6.38, alpha: 1 });
+  });
+
+  it("Supported by `getFormat`", () => {
+    expect(getFormat({ l: 50, a: 0, b: 0, alpha: 1 })).toBe("lab");
   });
 });
 
@@ -171,6 +180,11 @@ describe("lch", () => {
     expect(colord("lch(50% 50 100grad)").toLch().h).toBe(90);
     expect(colord("lch(50% 50 0.25turn)").toLch().h).toBe(90);
     expect(colord("lch(50% 50 1.5708rad)").toLch().h).toBe(90);
+  });
+
+  it("Supported by `getFormat`", () => {
+    expect(getFormat("lch(50% 50 180deg)")).toBe("lch");
+    expect(getFormat({ l: 50, c: 50, h: 180 })).toBe("lch");
   });
 });
 
@@ -227,6 +241,11 @@ describe("names", () => {
     expect(colord("yellow").isValid()).toBe(true);
     expect(colord("sunyellow").isValid()).toBe(false);
   });
+
+  it("Supported by `getFormat`", () => {
+    expect(getFormat("transparent")).toBe("name");
+    expect(getFormat("yellow")).toBe("name");
+  });
 });
 
 describe("xyz", () => {
@@ -245,5 +264,9 @@ describe("xyz", () => {
     expect(colord("#ffffff").toXyz()).toMatchObject({ x: 96.42, y: 100, z: 82.52, a: 1 });
     expect(colord("#5cbf54").toXyz()).toMatchObject({ x: 26, y: 40.27, z: 11.54, a: 1 });
     expect(colord("#00000000").toXyz()).toMatchObject({ x: 0, y: 0, z: 0, a: 0 });
+  });
+
+  it("Supported by `getFormat`", () => {
+    expect(getFormat({ x: 50, y: 50, z: 50 })).toBe("xyz");
   });
 });


### PR DESCRIPTION
Closes #43

```js
import { getFormat } from 'colord'

getFormat("#000") // "hex"
getFormat("rgba(128, 128, 128, 1)") // "rgb"
getFormat("hsl(180, 50, 50)") // "hsl"
getFormat({ r: 128, g: 128, b: 128, a: 0.5 }) // "rgb"
getFormat({ h: 180, s: 50, l: 50, a: 0.5 }) // "hsl"
getFormat({ h: 180, s: 50, v: 50, a: 0.5 }) // "hsv"
getFormat("red") // "name"
getFormat("disco-dancing") // undefined
getFormat({ w: 1, u: 2, t: 3 }) // undefined
```