### PR TITLE
Permissive names parser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### Next
+
+- Parse a color name disregarding the case
+
 ### 1.7.0
 
 - New `getFormat` utility

--- a/src/plugins/names.ts
+++ b/src/plugins/names.ts
@@ -180,7 +180,7 @@ const namesPlugin: Plugin = (ColordClass, parsers): void => {
 
   // Add CSS color names parser.
   const parseColorName: ParseFunction<string> = (input: string): RgbaColor | null => {
-    const name = input.trim();
+    const name = input.trim().toLowerCase();
     const hex = name === "transparent" ? "#0000" : NAME_HEX_STORE[name];
     if (hex) return new ColordClass(hex).toRgb();
     return null;

--- a/tests/plugins.test.ts
+++ b/tests/plugins.test.ts
@@ -220,6 +220,12 @@ describe("names", () => {
     expect(colord("rebeccapurple").toHex()).toBe("#663399");
   });
 
+  it("Ignores the case and extra whitespaces", () => {
+    expect(colord("White ").toHex()).toBe("#ffffff");
+    expect(colord(" YELLOW").toHex()).toBe("#ffff00");
+    expect(colord("  REbeccapurpLE ").toHex()).toBe("#663399");
+  });
+
   it("Converts a color to CSS name", () => {
     expect(colord("#F00").toName()).toBe("red");
   });


### PR DESCRIPTION
Makes the `names` plugin parser more user-friendly. See new test cases for more details.