### PR TITLE
Bump actions/setup-node from v1 to v2

### DIFF
--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -15,7 +15,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm install


### PR DESCRIPTION
## Changes:

- Bump `actions/setup-node` from `v1` to `v2`

## Context:

`actions/setup-node` has a newer stable release: `v2`.
It's a good idea to use the latest stable actions as those will continue to get security updates and improvements.

The tests should continue to work just fine. 😉 

Change-log for `v2`: https://github.com/actions/setup-node#v2