### PR TITLE
Plugin/mix-extended

### DIFF
--- a/README.md
+++ b/README.md
@@ -512,7 +512,8 @@ import mixPlugin from "colord/plugins/mix";
 
 extend([mixPlugin]);
 
-colord("#ff0000").tints().map(color => color.toHex()) // ["#ff0000", "#ff5c39", "#ff8b68", "#ffb399", "#ffd9cb", "#ffffff"];
+const color = colord("#ff0000");
+color.tints(3).map((c) => c.toHex()); // ["#ff0000", "#ff9f80", "#ffffff"];
 ```
 
 </details>
@@ -528,7 +529,8 @@ import mixPlugin from "colord/plugins/mix";
 
 extend([mixPlugin]);
 
-colord("#ff0000").shades().map(color => color.toHex()) // ["#ff0000", "#c81707", "#931c0b", "#621a0b", "#341306", "#000000"];
+const color = colord("#ff0000");
+color.shades(3).map((c) => c.toHex()); // ["#ff0000", "#7a1b0b", "#000000"];
 ```
 
 </details>
@@ -544,7 +546,8 @@ import mixPlugin from "colord/plugins/mix";
 
 extend([mixPlugin]);
 
-colord("#ff0000").tones().map(color => color.toHex()) // ["#ff0000", "#ea4023", "#d4583b", "#bc6952", "#a17669", "#808080"];
+const color = colord("#ff0000");
+color.tones(3).map((c) => c.toHex()); // ["#ff0000", "#c86147", "#808080"];
 ```
 
 </details>
@@ -875,17 +878,17 @@ colord("#cd853f").mix("#eee8aa", 0.6).toHex(); // "#e3c07e"
 colord("#008080").mix("#808000", 0.35).toHex(); // "#50805d"
 ```
 
-Also, plugin provides special mixtures such as [tints, shades, and tones](https://en.wikipedia.org/wiki/Tints_and_shades):
+Also, the plugin provides special mixtures such as [tints, shades, and tones](https://en.wikipedia.org/wiki/Tints_and_shades):
 
 <div align="center">
-<image src="https://upload.wikimedia.org/wikipedia/commons/thumb/d/d6/Tint-tone-shade.svg/320px-Tint-tone-shade.svg.png" alt="tints, shades, and tones mixtures">
+<img src="https://upload.wikimedia.org/wikipedia/commons/thumb/d/d6/Tint-tone-shade.svg/320px-Tint-tone-shade.svg.png" alt="tints, shades, and tones mixtures" />
 </div>
 
 ```js
-colord("#ff0000").tints().map(color => color.toHex()) // ["#ff0000", "#ff5c39", "#ff8b68", "#ffb399", "#ffd9cb", "#ffffff"];
-colord("#ff0000").shades().map(color => color.toHex()) // ["#ff0000", "#c81707", "#931c0b", "#621a0b", "#341306", "#000000"];
-colord("#ff0000").tones().map(color => color.toHex()) // ["#ff0000", "#ea4023", "#d4583b", "#bc6952", "#a17669", "#808080"];
-
+const color = colord("#ff0000");
+color.tints(3).map((c) => c.toHex()); // ["#ff0000", "#ff9f80", "#ffffff"];
+color.shades(3).map((c) => c.toHex()); // ["#ff0000", "#7a1b0b", "#000000"];
+color.tones(3).map((c) => c.toHex()); // ["#ff0000", "#c86147", "#808080"];
 ```
 
 </details>

--- a/README.md
+++ b/README.md
@@ -502,6 +502,54 @@ colord("#008080").mix("#808000", 0.35).toHex(); // "#50805d"
 </details>
 
 <details>
+  <summary><b><code>.tints(colors = 5)</code></b> (<b>mix</b> plugin)</summary>
+
+Provides functionality to generate [tints](https://en.wikipedia.org/wiki/Tints_and_shades) of a color. Returns an array of `Colord` instances, including the original color.
+
+```js
+import { colord, extends } from "colord";
+import mixPlugin from "colord/plugins/mix";
+
+extend([mixPlugin]);
+
+colord("#ff0000").tints(10).map(color => color.toHex()) // ["#ff0000", "#ff3f20", "#ff5c39", "#ff7551", "#ff8b68", "#ff9f80", "#ffb399", "#ffc6b2", "#ffd9cb", "#ffece5", "#ffffff"];
+```
+
+</details>
+
+<details>
+  <summary><b><code>.shades(colors = 5)</code></b> (<b>mix</b> plugin)</summary>
+
+Provides functionality to generate [shades](https://en.wikipedia.org/wiki/Tints_and_shades) of a color. Returns an array of `Colord` instances, including the original color.
+
+```js
+import { colord, extends } from "colord";
+import mixPlugin from "colord/plugins/mix";
+
+extend([mixPlugin]);
+
+lord("#ff0000").shades(10).map(color => color.toHex()) // ["#ff0000", "#e31004", "#c81707", "#ad1b09", "#931c0b", "#7a1b0b", "#621a0b", "#4a1709", "#341306", "#200d03", "#000000"];
+```
+
+</details>
+
+<details>
+  <summary><b><code>.shades(colors = 5)</code></b> (<b>mix</b> plugin)</summary>
+
+Provides functionality to generate [tones](https://en.wikipedia.org/wiki/Tints_and_shades) of a color. Returns an array of `Colord` instances, including the original color.
+
+```js
+import { colord, extends } from "colord";
+import mixPlugin from "colord/plugins/mix";
+
+extend([mixPlugin]);
+
+colord("#ff0000").tones(10).map(color => color.toHex()) // ["#ff0000", "#f52d14", "#ea4023", "#df4e30", "#d4583b", "#c86147", "#bc6952", "#af705e", "#a17669", "#917b75", "#808080"];
+```
+
+</details>
+
+<details>
   <summary><b><code>.harmonies(type = "complementary")</code></b> (<b>harmonies</b> plugin)</summary>
 
 Provides functionality to generate [harmony colors](<https://en.wikipedia.org/wiki/Harmony_(color)>). Returns an array of `Colord` instances.
@@ -809,7 +857,7 @@ colord("#646464").alpha(0.5).toLchString(); // "lch(42.37% 0 0 / 0.5)"
 <details>
   <summary><b><code>mix</code> (Color mixing)</b> <i>0.9 KB</i></summary>
 
-A plugin adding a color mixing utility.
+A plugin adding a color mixing utilities.
 
 In contrast to other libraries that perform RGB values mixing, Colord mixes colors through [LAB color space](https://en.wikipedia.org/wiki/CIELAB_color_space). This approach produces better results and doesn't have the drawbacks the legacy way has.
 
@@ -825,6 +873,19 @@ colord("#ffffff").mix("#000000").toHex(); // "#777777"
 colord("#800080").mix("#dda0dd").toHex(); // "#af5cae"
 colord("#cd853f").mix("#eee8aa", 0.6).toHex(); // "#e3c07e"
 colord("#008080").mix("#808000", 0.35).toHex(); // "#50805d"
+```
+
+Also, plugin provides special mixtures such as [tints, shades, and tones](https://en.wikipedia.org/wiki/Tints_and_shades):
+
+<div align="center">
+<image src="https://upload.wikimedia.org/wikipedia/commons/thumb/d/d6/Tint-tone-shade.svg/320px-Tint-tone-shade.svg.png" alt="tints, shades, and tones mixtures">
+</div>
+
+```js
+colord("#ff0000").tints(10).map(color => color.toHex()) // ["#ff0000", "#ff3f20", "#ff5c39", "#ff7551", "#ff8b68", "#ff9f80", "#ffb399", "#ffc6b2", "#ffd9cb", "#ffece5", "#ffffff"];
+colord("#ff0000").shades(10).map(color => color.toHex()) // ["#ff0000", "#e31004", "#c81707", "#ad1b09", "#931c0b", "#7a1b0b", "#621a0b", "#4a1709", "#341306", "#200d03", "#000000"];
+colord("#ff0000").tones(10).map(color => color.toHex()) // ["#ff0000", "#f52d14", "#ea4023", "#df4e30", "#d4583b", "#c86147", "#bc6952", "#af705e", "#a17669", "#917b75", "#808080"];
+
 ```
 
 </details>

--- a/README.md
+++ b/README.md
@@ -502,7 +502,7 @@ colord("#008080").mix("#808000", 0.35).toHex(); // "#50805d"
 </details>
 
 <details>
-  <summary><b><code>.tints(colors = 5)</code></b> (<b>mix</b> plugin)</summary>
+  <summary><b><code>.tints(count = 5)</code></b> (<b>mix</b> plugin)</summary>
 
 Provides functionality to generate [tints](https://en.wikipedia.org/wiki/Tints_and_shades) of a color. Returns an array of `Colord` instances, including the original color.
 
@@ -512,13 +512,13 @@ import mixPlugin from "colord/plugins/mix";
 
 extend([mixPlugin]);
 
-colord("#ff0000").tints(10).map(color => color.toHex()) // ["#ff0000", "#ff3f20", "#ff5c39", "#ff7551", "#ff8b68", "#ff9f80", "#ffb399", "#ffc6b2", "#ffd9cb", "#ffece5", "#ffffff"];
+colord("#ff0000").tints().map(color => color.toHex()) // ["#ff0000", "#ff5c39", "#ff8b68", "#ffb399", "#ffd9cb", "#ffffff"];
 ```
 
 </details>
 
 <details>
-  <summary><b><code>.shades(colors = 5)</code></b> (<b>mix</b> plugin)</summary>
+  <summary><b><code>.shades(count = 5)</code></b> (<b>mix</b> plugin)</summary>
 
 Provides functionality to generate [shades](https://en.wikipedia.org/wiki/Tints_and_shades) of a color. Returns an array of `Colord` instances, including the original color.
 
@@ -528,13 +528,13 @@ import mixPlugin from "colord/plugins/mix";
 
 extend([mixPlugin]);
 
-lord("#ff0000").shades(10).map(color => color.toHex()) // ["#ff0000", "#e31004", "#c81707", "#ad1b09", "#931c0b", "#7a1b0b", "#621a0b", "#4a1709", "#341306", "#200d03", "#000000"];
+colord("#ff0000").shades().map(color => color.toHex()) // ["#ff0000", "#c81707", "#931c0b", "#621a0b", "#341306", "#000000"];
 ```
 
 </details>
 
 <details>
-  <summary><b><code>.tones(colors = 5)</code></b> (<b>mix</b> plugin)</summary>
+  <summary><b><code>.tones(count = 5)</code></b> (<b>mix</b> plugin)</summary>
 
 Provides functionality to generate [tones](https://en.wikipedia.org/wiki/Tints_and_shades) of a color. Returns an array of `Colord` instances, including the original color.
 
@@ -544,7 +544,7 @@ import mixPlugin from "colord/plugins/mix";
 
 extend([mixPlugin]);
 
-colord("#ff0000").tones(10).map(color => color.toHex()) // ["#ff0000", "#f52d14", "#ea4023", "#df4e30", "#d4583b", "#c86147", "#bc6952", "#af705e", "#a17669", "#917b75", "#808080"];
+colord("#ff0000").tones().map(color => color.toHex()) // ["#ff0000", "#ea4023", "#d4583b", "#bc6952", "#a17669", "#808080"];
 ```
 
 </details>
@@ -855,7 +855,7 @@ colord("#646464").alpha(0.5).toLchString(); // "lch(42.37% 0 0 / 0.5)"
 </details>
 
 <details>
-  <summary><b><code>mix</code> (Color mixing)</b> <i>0.9 KB</i></summary>
+  <summary><b><code>mix</code> (Color mixing)</b> <i>0.96 KB</i></summary>
 
 A plugin adding a color mixing utilities.
 
@@ -882,9 +882,9 @@ Also, plugin provides special mixtures such as [tints, shades, and tones](https:
 </div>
 
 ```js
-colord("#ff0000").tints(10).map(color => color.toHex()) // ["#ff0000", "#ff3f20", "#ff5c39", "#ff7551", "#ff8b68", "#ff9f80", "#ffb399", "#ffc6b2", "#ffd9cb", "#ffece5", "#ffffff"];
-colord("#ff0000").shades(10).map(color => color.toHex()) // ["#ff0000", "#e31004", "#c81707", "#ad1b09", "#931c0b", "#7a1b0b", "#621a0b", "#4a1709", "#341306", "#200d03", "#000000"];
-colord("#ff0000").tones(10).map(color => color.toHex()) // ["#ff0000", "#f52d14", "#ea4023", "#df4e30", "#d4583b", "#c86147", "#bc6952", "#af705e", "#a17669", "#917b75", "#808080"];
+colord("#ff0000").tints().map(color => color.toHex()) // ["#ff0000", "#ff5c39", "#ff8b68", "#ffb399", "#ffd9cb", "#ffffff"];
+colord("#ff0000").shades().map(color => color.toHex()) // ["#ff0000", "#c81707", "#931c0b", "#621a0b", "#341306", "#000000"];
+colord("#ff0000").tones().map(color => color.toHex()) // ["#ff0000", "#ea4023", "#d4583b", "#bc6952", "#a17669", "#808080"];
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -534,7 +534,7 @@ lord("#ff0000").shades(10).map(color => color.toHex()) // ["#ff0000", "#e31004",
 </details>
 
 <details>
-  <summary><b><code>.shades(colors = 5)</code></b> (<b>mix</b> plugin)</summary>
+  <summary><b><code>.tones(colors = 5)</code></b> (<b>mix</b> plugin)</summary>
 
 Provides functionality to generate [tones](https://en.wikipedia.org/wiki/Tints_and_shades) of a color. Returns an array of `Colord` instances, including the original color.
 

--- a/src/plugins/mix.ts
+++ b/src/plugins/mix.ts
@@ -1,10 +1,6 @@
 import { AnyColor } from "../types";
 import { Plugin } from "../extend";
 import { mix } from "../manipulate/mix";
-import { Colord } from "../colord";
-
-type Mixer = (color: AnyColor | Colord, ratio: number) => Colord;
-type PaletteMixer = (color: string, colors: number, mixer: Mixer) => Colord[];
 
 declare module "../colord" {
   interface Colord {
@@ -49,7 +45,7 @@ const mixPlugin: Plugin = (ColordClass): void => {
       palette.push(this.mix(color, ratio));
     }
     return palette;
-  }
+  };
 
   ColordClass.prototype.tints = function (colors) {
     return this._mixPalette("#ffffff", colors);

--- a/src/plugins/mix.ts
+++ b/src/plugins/mix.ts
@@ -6,7 +6,7 @@ import { Colord } from "../colord";
 declare module "../colord" {
   interface Colord {
     /**
-     * Produces a mixture of two count through CIE LAB color space and returns a new Colord instance.
+     * Produces a mixture of two colors through CIE LAB color space and returns a new Colord instance.
      */
     mix(color2: AnyColor | Colord, ratio?: number): Colord;
 
@@ -43,7 +43,7 @@ const mixPlugin: Plugin = (ColordClass): void => {
    */
   function mixPalette(source: Colord, hex: string, count = 5): Colord[] {
     const palette = [];
-    const step = 1 / Math.max(1, count);
+    const step = 1 / (count - 1);
     for (let ratio = 0; ratio <= 1; ratio += step) {
       palette.push(source.mix(hex, ratio));
     }

--- a/src/plugins/mix.ts
+++ b/src/plugins/mix.ts
@@ -1,6 +1,7 @@
 import { AnyColor } from "../types";
 import { Plugin } from "../extend";
 import { mix } from "../manipulate/mix";
+import { Colord } from "../colord";
 
 declare module "../colord" {
   interface Colord {
@@ -23,8 +24,6 @@ declare module "../colord" {
      * Generates a tones palette based on original color.
      */
     tones(colors: number): Colord[];
-
-    _mixPalette(color: AnyColor | Colord, colors: number): Colord[];
   }
 }
 
@@ -39,24 +38,27 @@ const mixPlugin: Plugin = (ColordClass): void => {
     return new ColordClass(mixture);
   };
 
-  ColordClass.prototype._mixPalette = function (color, colors = 5) {
+  /**
+   * Generate a palette from mixing a source color with another.
+   */
+  function mixPalette(source: Colord, hex: string, colors = 5): Colord[] {
     const palette = [];
     for (let ratio = 0; ratio <= 1; ratio += 1 / colors) {
-      palette.push(this.mix(color, ratio));
+      palette.push(source.mix(hex, ratio));
     }
     return palette;
-  };
+  }
 
   ColordClass.prototype.tints = function (colors) {
-    return this._mixPalette("#ffffff", colors);
+    return mixPalette(this, "#fff", colors);
   };
 
   ColordClass.prototype.shades = function (colors) {
-    return this._mixPalette("#000000", colors);
+    return mixPalette(this, "#000", colors);
   };
 
   ColordClass.prototype.tones = function (colors) {
-    return this._mixPalette("#808080", colors);
+    return mixPalette(this, "#808080", colors);
   };
 };
 

--- a/src/plugins/mix.ts
+++ b/src/plugins/mix.ts
@@ -6,24 +6,24 @@ import { Colord } from "../colord";
 declare module "../colord" {
   interface Colord {
     /**
-     * Produces a mixture of two colors through CIE LAB color space and returns a new Colord instance.
+     * Produces a mixture of two count through CIE LAB color space and returns a new Colord instance.
      */
     mix(color2: AnyColor | Colord, ratio?: number): Colord;
 
     /**
      * Generates a tints palette based on original color.
      */
-    tints(colors: number): Colord[];
+    tints(count?: number): Colord[];
 
     /**
      * Generates a shades palette based on original color.
      */
-    shades(colors: number): Colord[];
+    shades(count?: number): Colord[];
 
     /**
      * Generates a tones palette based on original color.
      */
-    tones(colors: number): Colord[];
+    tones(count?: number): Colord[];
   }
 }
 
@@ -41,24 +41,25 @@ const mixPlugin: Plugin = (ColordClass): void => {
   /**
    * Generate a palette from mixing a source color with another.
    */
-  function mixPalette(source: Colord, hex: string, colors = 5): Colord[] {
+  function mixPalette(source: Colord, hex: string, count = 5): Colord[] {
     const palette = [];
-    for (let ratio = 0; ratio <= 1; ratio += 1 / colors) {
+    const step = 1 / Math.max(1, count);
+    for (let ratio = 0; ratio <= 1; ratio += step) {
       palette.push(source.mix(hex, ratio));
     }
     return palette;
   }
 
-  ColordClass.prototype.tints = function (colors) {
-    return mixPalette(this, "#fff", colors);
+  ColordClass.prototype.tints = function (count) {
+    return mixPalette(this, "#fff", count);
   };
 
-  ColordClass.prototype.shades = function (colors) {
-    return mixPalette(this, "#000", colors);
+  ColordClass.prototype.shades = function (count) {
+    return mixPalette(this, "#000", count);
   };
 
-  ColordClass.prototype.tones = function (colors) {
-    return mixPalette(this, "#808080", colors);
+  ColordClass.prototype.tones = function (count) {
+    return mixPalette(this, "#808080", count);
   };
 };
 

--- a/src/plugins/mix.ts
+++ b/src/plugins/mix.ts
@@ -1,6 +1,10 @@
 import { AnyColor } from "../types";
 import { Plugin } from "../extend";
 import { mix } from "../manipulate/mix";
+import { Colord } from "../colord";
+
+type Mixer = (color: AnyColor | Colord, ratio: number) => Colord;
+type PaletteMixer = (color: string, colors: number, mixer: Mixer) => Colord[];
 
 declare module "../colord" {
   interface Colord {
@@ -8,11 +12,28 @@ declare module "../colord" {
      * Produces a mixture of two colors through CIE LAB color space and returns a new Colord instance.
      */
     mix(color2: AnyColor | Colord, ratio?: number): Colord;
+
+    /**
+     * Generates a tints palette based on original color.
+     */
+    tints(colors: number): Colord[];
+
+    /**
+     * Generates a shades palette based on original color.
+     */
+    shades(colors: number): Colord[];
+
+    /**
+     * Generates a tones palette based on original color.
+     */
+    tones(colors: number): Colord[];
+
+    _mixPalette(color: AnyColor | Colord, colors: number): Colord[];
   }
 }
 
 /**
- * A plugin adding a color mixing utility.
+ * A plugin adding a color mixing utilities.
  */
 const mixPlugin: Plugin = (ColordClass): void => {
   ColordClass.prototype.mix = function (color2, ratio = 0.5) {
@@ -20,6 +41,26 @@ const mixPlugin: Plugin = (ColordClass): void => {
 
     const mixture = mix(this.toRgb(), instance2.toRgb(), ratio);
     return new ColordClass(mixture);
+  };
+
+  ColordClass.prototype._mixPalette = function (color, colors = 5) {
+    const palette = [];
+    for (let ratio = 0; ratio <= 1; ratio += 1 / colors) {
+      palette.push(this.mix(color, ratio));
+    }
+    return palette;
+  }
+
+  ColordClass.prototype.tints = function (colors) {
+    return this._mixPalette("#ffffff", colors);
+  };
+
+  ColordClass.prototype.shades = function (colors) {
+    return this._mixPalette("#000000", colors);
+  };
+
+  ColordClass.prototype.tones = function (colors) {
+    return this._mixPalette("#808080", colors);
   };
 };
 

--- a/src/plugins/mix.ts
+++ b/src/plugins/mix.ts
@@ -44,8 +44,8 @@ const mixPlugin: Plugin = (ColordClass): void => {
   function mixPalette(source: Colord, hex: string, count = 5): Colord[] {
     const palette = [];
     const step = 1 / (count - 1);
-    for (let ratio = 0; ratio <= 1; ratio += step) {
-      palette.push(source.mix(hex, ratio));
+    for (let i = 0; i <= count - 1; i++) {
+      palette.push(source.mix(hex, step * i));
     }
     return palette;
   }

--- a/tests/plugins.test.ts
+++ b/tests/plugins.test.ts
@@ -275,6 +275,18 @@ describe("mix", () => {
     expect(colord("#ffffff").mix("#ffffff").toHex()).toBe("#ffffff");
     expect(colord("#000000").mix("#000000").toHex()).toBe("#000000");
   });
+
+  it("Generates a tints palette", () => {
+    expect(colord("#ff0000").tints(10).map(color => color.toHex())).toEqual(["#ff0000", "#ff3f20", "#ff5c39", "#ff7551", "#ff8b68", "#ff9f80", "#ffb399", "#ffc6b2", "#ffd9cb", "#ffece5", "#ffffff"]);
+  });
+
+  it("Generates a shades palette", () => {
+    expect(colord("#ff0000").shades(10).map(color => color.toHex())).toEqual(["#ff0000", "#e31004", "#c81707", "#ad1b09", "#931c0b", "#7a1b0b", "#621a0b", "#4a1709", "#341306", "#200d03", "#000000"]);
+  });
+
+  it("Generates a tones palette", () => {
+    expect(colord("#ff0000").tones(10).map(color => color.toHex())).toEqual(["#ff0000", "#f52d14", "#ea4023", "#df4e30", "#d4583b", "#c86147", "#bc6952", "#af705e", "#a17669", "#917b75", "#808080"]);
+  });
 });
 
 describe("names", () => {

--- a/tests/plugins.test.ts
+++ b/tests/plugins.test.ts
@@ -277,14 +277,29 @@ describe("mix", () => {
   });
 
   it("Generates a tints palette", () => {
+    expect(colord("#ff0000").tints(-5).map(color => color.toHex())).toEqual(["#ff0000", "#ffffff"]);
+    expect(colord("#ff0000").tints(1).map(color => color.toHex())).toEqual(["#ff0000", "#ffffff"]);
+    expect(colord("#ff0000").tints(2).map(color => color.toHex())).toEqual(["#ff0000", "#ff9f80", "#ffffff"]);
+    expect(colord("#ff0000").tints(3).map(color => color.toHex())).toEqual(["#ff0000", "#ff7c59", "#ffc0a9", "#ffffff"]);
+    expect(colord("#ff0000").tints().map(color => color.toHex())).toEqual(["#ff0000", "#ff5c39", "#ff8b68", "#ffb399", "#ffd9cb", "#ffffff"]);
     expect(colord("#ff0000").tints(10).map(color => color.toHex())).toEqual(["#ff0000", "#ff3f20", "#ff5c39", "#ff7551", "#ff8b68", "#ff9f80", "#ffb399", "#ffc6b2", "#ffd9cb", "#ffece5", "#ffffff"]);
   });
 
   it("Generates a shades palette", () => {
+    expect(colord("#ff0000").shades(-5).map(color => color.toHex())).toEqual(["#ff0000", "#000000"]);
+    expect(colord("#ff0000").shades(1).map(color => color.toHex())).toEqual(["#ff0000", "#000000"]);
+    expect(colord("#ff0000").shades(2).map(color => color.toHex())).toEqual(["#ff0000", "#7a1b0b", "#000000"]);
+    expect(colord("#ff0000").shades(3).map(color => color.toHex())).toEqual(["#ff0000", "#a41b0a", "#52180a", "#000000"]);
+    expect(colord("#ff0000").shades().map(color => color.toHex())).toEqual(["#ff0000", "#c81707", "#931c0b", "#621a0b", "#341306", "#000000"]);
     expect(colord("#ff0000").shades(10).map(color => color.toHex())).toEqual(["#ff0000", "#e31004", "#c81707", "#ad1b09", "#931c0b", "#7a1b0b", "#621a0b", "#4a1709", "#341306", "#200d03", "#000000"]);
   });
 
   it("Generates a tones palette", () => {
+    expect(colord("#ff0000").tones(-5).map(color => color.toHex())).toEqual(["#ff0000", "#808080"]);
+    expect(colord("#ff0000").tones(1).map(color => color.toHex())).toEqual(["#ff0000", "#808080"]);
+    expect(colord("#ff0000").tones(2).map(color => color.toHex())).toEqual(["#ff0000", "#c86147", "#808080"]);
+    expect(colord("#ff0000").tones(3).map(color => color.toHex())).toEqual(["#ff0000", "#dc5134", "#b36e5a", "#808080"]);
+    expect(colord("#ff0000").tones().map(color => color.toHex())).toEqual(["#ff0000", "#ea4023", "#d4583b", "#bc6952", "#a17669", "#808080"]);
     expect(colord("#ff0000").tones(10).map(color => color.toHex())).toEqual(["#ff0000", "#f52d14", "#ea4023", "#df4e30", "#d4583b", "#c86147", "#bc6952", "#af705e", "#a17669", "#917b75", "#808080"]);
   });
 });

--- a/tests/plugins.test.ts
+++ b/tests/plugins.test.ts
@@ -285,18 +285,21 @@ describe("mix", () => {
     check(colord("#ff0000").tints(2), ["#ff0000", "#ffffff"]);
     check(colord("#ff0000").tints(3), ["#ff0000", "#ff9f80", "#ffffff"]);
     check(colord("#ff0000").tints(), ["#ff0000", "#ff6945", "#ff9f80", "#ffd0be", "#ffffff"]);
+    expect(colord("#aabbcc").tints(499)).toHaveLength(499);
   });
 
   it("Generates a shades palette", () => {
     check(colord("#ff0000").shades(2), ["#ff0000", "#000000"]);
     check(colord("#ff0000").shades(3), ["#ff0000", "#7a1b0b", "#000000"]);
     check(colord("#ff0000").shades(), ["#ff0000", "#ba1908", "#7a1b0b", "#3f1508", "#000000"]);
+    expect(colord("#aabbcc").shades(333)).toHaveLength(333);
   });
 
   it("Generates a tones palette", () => {
     check(colord("#ff0000").tones(2), ["#ff0000", "#808080"]);
     check(colord("#ff0000").tones(3), ["#ff0000", "#c86147", "#808080"]);
     check(colord("#ff0000").tones(), ["#ff0000", "#e54729", "#c86147", "#a87363", "#808080"]);
+    expect(colord("#aabbcc").tones(987)).toHaveLength(987);
   });
 });
 

--- a/tests/plugins.test.ts
+++ b/tests/plugins.test.ts
@@ -1,4 +1,4 @@
-import { colord, getFormat, extend } from "../src/";
+import { colord, getFormat, extend, Colord } from "../src/";
 import a11yPlugin from "../src/plugins/a11y";
 import cmykPlugin from "../src/plugins/cmyk";
 import harmoniesPlugin, { HarmonyType } from "../src/plugins/harmonies";
@@ -276,31 +276,27 @@ describe("mix", () => {
     expect(colord("#000000").mix("#000000").toHex()).toBe("#000000");
   });
 
+  const check = (colors: Colord[], expected: string[]) => {
+    const hexes = colors.map((value) => value.toHex());
+    return expect(hexes).toEqual(expected);
+  };
+
   it("Generates a tints palette", () => {
-    expect(colord("#ff0000").tints(-5).map(color => color.toHex())).toEqual(["#ff0000", "#ffffff"]);
-    expect(colord("#ff0000").tints(1).map(color => color.toHex())).toEqual(["#ff0000", "#ffffff"]);
-    expect(colord("#ff0000").tints(2).map(color => color.toHex())).toEqual(["#ff0000", "#ff9f80", "#ffffff"]);
-    expect(colord("#ff0000").tints(3).map(color => color.toHex())).toEqual(["#ff0000", "#ff7c59", "#ffc0a9", "#ffffff"]);
-    expect(colord("#ff0000").tints().map(color => color.toHex())).toEqual(["#ff0000", "#ff5c39", "#ff8b68", "#ffb399", "#ffd9cb", "#ffffff"]);
-    expect(colord("#ff0000").tints(10).map(color => color.toHex())).toEqual(["#ff0000", "#ff3f20", "#ff5c39", "#ff7551", "#ff8b68", "#ff9f80", "#ffb399", "#ffc6b2", "#ffd9cb", "#ffece5", "#ffffff"]);
+    check(colord("#ff0000").tints(2), ["#ff0000", "#ffffff"]);
+    check(colord("#ff0000").tints(3), ["#ff0000", "#ff9f80", "#ffffff"]);
+    check(colord("#ff0000").tints(), ["#ff0000", "#ff6945", "#ff9f80", "#ffd0be", "#ffffff"]);
   });
 
   it("Generates a shades palette", () => {
-    expect(colord("#ff0000").shades(-5).map(color => color.toHex())).toEqual(["#ff0000", "#000000"]);
-    expect(colord("#ff0000").shades(1).map(color => color.toHex())).toEqual(["#ff0000", "#000000"]);
-    expect(colord("#ff0000").shades(2).map(color => color.toHex())).toEqual(["#ff0000", "#7a1b0b", "#000000"]);
-    expect(colord("#ff0000").shades(3).map(color => color.toHex())).toEqual(["#ff0000", "#a41b0a", "#52180a", "#000000"]);
-    expect(colord("#ff0000").shades().map(color => color.toHex())).toEqual(["#ff0000", "#c81707", "#931c0b", "#621a0b", "#341306", "#000000"]);
-    expect(colord("#ff0000").shades(10).map(color => color.toHex())).toEqual(["#ff0000", "#e31004", "#c81707", "#ad1b09", "#931c0b", "#7a1b0b", "#621a0b", "#4a1709", "#341306", "#200d03", "#000000"]);
+    check(colord("#ff0000").shades(2), ["#ff0000", "#000000"]);
+    check(colord("#ff0000").shades(3), ["#ff0000", "#7a1b0b", "#000000"]);
+    check(colord("#ff0000").shades(), ["#ff0000", "#ba1908", "#7a1b0b", "#3f1508", "#000000"]);
   });
 
   it("Generates a tones palette", () => {
-    expect(colord("#ff0000").tones(-5).map(color => color.toHex())).toEqual(["#ff0000", "#808080"]);
-    expect(colord("#ff0000").tones(1).map(color => color.toHex())).toEqual(["#ff0000", "#808080"]);
-    expect(colord("#ff0000").tones(2).map(color => color.toHex())).toEqual(["#ff0000", "#c86147", "#808080"]);
-    expect(colord("#ff0000").tones(3).map(color => color.toHex())).toEqual(["#ff0000", "#dc5134", "#b36e5a", "#808080"]);
-    expect(colord("#ff0000").tones().map(color => color.toHex())).toEqual(["#ff0000", "#ea4023", "#d4583b", "#bc6952", "#a17669", "#808080"]);
-    expect(colord("#ff0000").tones(10).map(color => color.toHex())).toEqual(["#ff0000", "#f52d14", "#ea4023", "#df4e30", "#d4583b", "#c86147", "#bc6952", "#af705e", "#a17669", "#917b75", "#808080"]);
+    check(colord("#ff0000").tones(2), ["#ff0000", "#808080"]);
+    check(colord("#ff0000").tones(3), ["#ff0000", "#c86147", "#808080"]);
+    check(colord("#ff0000").tones(), ["#ff0000", "#e54729", "#c86147", "#a87363", "#808080"]);
   });
 });
 


### PR DESCRIPTION
Extending the functionality of `mix` plugin by generating mixtures of colors such as [tints, shades, and tones](https://en.wikipedia.org/wiki/Tints_and_shades) with `.tones(colors = 5)`, `.shades(colors = 5)`, and `.tones(colors = 5)` methods respectively.