### PR TITLE
HEX Simplifications

### DIFF
--- a/package.json
+++ b/package.json
@@ -140,7 +140,8 @@
     ]
   },
   "prettier": {
-    "printWidth": 100
+    "printWidth": 100,
+    "endOfLine": "auto"
   },
   "size-limit": [
     {

--- a/src/colorModels/hex.ts
+++ b/src/colorModels/hex.ts
@@ -2,41 +2,28 @@ import { RgbaColor } from "../types";
 import { round } from "../helpers";
 import { roundRgba } from "./rgb";
 
-const hexMatcher = /^#([0-9a-f]{3,8})$/i;
+const hexMatcher = /^#([0-9a-f]{3,4}|[0-9a-f]{6}|[0-9a-f]{8})$/i;
 
 /** Parses any valid Hex3, Hex4, Hex6 or Hex8 string and converts it to an RGBA object */
 export const parseHex = (hex: string): RgbaColor | null => {
   const hexMatch = hexMatcher.exec(hex);
-
   if (!hexMatch) return null;
 
-  hex = hexMatch[1];
+  hex = hex.slice(1); // remove the '#' from the front
 
-  if (hex.length <= 4) {
-    return {
-      r: parseInt(hex[0] + hex[0], 16),
-      g: parseInt(hex[1] + hex[1], 16),
-      b: parseInt(hex[2] + hex[2], 16),
-      a: hex.length === 4 ? round(parseInt(hex[3] + hex[3], 16) / 255, 2) : 1,
-    };
-  }
+  const hexParts =
+    hex.length > 5
+      ? hex.match(/[0-9a-f]{2}/gi)
+      : hex.match(/[0-9a-f]/gi)?.map((item) => item.repeat(2));
 
-  if (hex.length === 6 || hex.length === 8) {
-    return {
-      r: parseInt(hex.substr(0, 2), 16),
-      g: parseInt(hex.substr(2, 2), 16),
-      b: parseInt(hex.substr(4, 2), 16),
-      a: hex.length === 8 ? round(parseInt(hex.substr(6, 2), 16) / 255, 2) : 1,
-    };
-  }
+  const [r, g, b, a] = hexParts?.map((elem) => parseInt(elem, 16)) ?? [0, 0, 0, 255]; // default values
 
-  return null;
+  return { r, g, b, a: hex.length % 4 === 0 ? round(a / 255, 2) : 1 };
 };
 
 /** Formats any decimal number (e.g. 128) as a hexadecimal string (e.g. "08") */
 const format = (number: number): string => {
-  const hex = number.toString(16);
-  return hex.length < 2 ? "0" + hex : hex;
+  return number.toString(16).padStart(2, "0");
 };
 
 /** Converts RGBA object to Hex6 or (if it has alpha channel) Hex8 string */


### PR DESCRIPTION
## Changed
- Adjusted hex matcher RegExp to reduce parsing logic

## Note
Without `"endOfLine": "auto"` in the prettier config section of `package.json`, I was getting a lot of end of line errors, which is why I added this.

---

closes #71