### PR TITLE
deltaE00 implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -711,6 +711,23 @@ colord("#e60000").isReadable("#ffff47", { level: "AAA", size: "large" }); // tru
 
 </details>
 
+<details>
+  <summary><b><code>.delta(color2 = "#FFF", options?)</code></b> (<b>lab</b> plugin)</summary>
+
+Calculates the perceived color difference between two colors.
+The difference calculated according to [Delta E2000](https://en.wikipedia.org/wiki/Color_difference#CIEDE2000).
+
+Returns the normalized value in range from [0, 1], where 0 is the same color and 1 are completely different.
+
+```js
+colord("#3296fa").delta("#197dc8") // 0.0989261
+colord("#faf0c8").delta("#fff") // 0.1447411
+colord("#afafaf").delta("#b4b4b4") // 0.0138414
+colord("#000").delta("#fff") // 1.0
+```
+
+</details>
+
 ### Color utilities
 
 <details>
@@ -828,6 +845,8 @@ colord("hwb(210 0% 60% / 50%)").toHex(); // "#00336680"
   <summary><b><code>lab</code> (CIE LAB color space)</b> <i>0.9 KB</i></summary>
 
 Adds support of [CIE LAB](https://en.wikipedia.org/wiki/CIELAB_color_space) color model. The conversion logic is ported from [CSS Color Module Level 4 Specification](https://www.w3.org/TR/css-color-4/#color-conversion-code).
+
+Also plugin provides `.delta` method for perceived color difference calculations.
 
 ```js
 import { colord, extend } from "colord";

--- a/README.md
+++ b/README.md
@@ -712,18 +712,17 @@ colord("#e60000").isReadable("#ffff47", { level: "AAA", size: "large" }); // tru
 </details>
 
 <details>
-  <summary><b><code>.delta(color2 = "#FFF", options?)</code></b> (<b>lab</b> plugin)</summary>
+  <summary><b><code>.delta(color2 = "#FFF")</code></b> (<b>lab</b> plugin)</summary>
 
 Calculates the perceived color difference between two colors.
 The difference calculated according to [Delta E2000](https://en.wikipedia.org/wiki/Color_difference#CIEDE2000).
-
-Returns the normalized value in range from [0, 1], where 0 is the same color and 1 are completely different.
+The return value is `0` if the colors are equal, `1` if they are entirely different.
 
 ```js
-colord("#3296fa").delta("#197dc8") // 0.099
-colord("#faf0c8").delta("#fff") // 0.148
-colord("#afafaf").delta("#b4b4b4") // 0.014
-colord("#000").delta("#fff") // 1.0
+colord("#3296fa").delta("#197dc8"); // 0.099
+colord("#faf0c8").delta("#ffffff"); // 0.148
+colord("#afafaf").delta("#b4b4b4"); // 0.014
+colord("#000000").delta("#ffffff"); // 1
 ```
 
 </details>
@@ -842,11 +841,11 @@ colord("hwb(210 0% 60% / 50%)").toHex(); // "#00336680"
 </details>
 
 <details>
-  <summary><b><code>lab</code> (CIE LAB color space)</b> <i>1.5 KB</i></summary>
+  <summary><b><code>lab</code> (CIE LAB color space)</b> <i>1.4 KB</i></summary>
 
 Adds support of [CIE LAB](https://en.wikipedia.org/wiki/CIELAB_color_space) color model. The conversion logic is ported from [CSS Color Module Level 4 Specification](https://www.w3.org/TR/css-color-4/#color-conversion-code).
 
-Also plugin provides `.delta` method for perceived color difference calculations.
+Also plugin provides `.delta` method for [perceived color difference calculations](https://en.wikipedia.org/wiki/Color_difference#CIEDE2000).
 
 ```js
 import { colord, extend } from "colord";
@@ -857,8 +856,8 @@ extend([labPlugin]);
 colord({ l: 53.24, a: 80.09, b: 67.2 }).toHex(); // "#ff0000"
 colord("#ffffff").toLab(); // { l: 100, a: 0, b: 0, alpha: 1 }
 
-colord("#afafaf").delta("#b4b4b4") // 0.014
-colord("#000").delta("#fff") // 1.0
+colord("#afafaf").delta("#b4b4b4"); // 0.014
+colord("#000000").delta("#ffffff"); // 1
 ```
 
 </details>

--- a/README.md
+++ b/README.md
@@ -720,9 +720,9 @@ The difference calculated according to [Delta E2000](https://en.wikipedia.org/wi
 Returns the normalized value in range from [0, 1], where 0 is the same color and 1 are completely different.
 
 ```js
-colord("#3296fa").delta("#197dc8") // 0.0989261
-colord("#faf0c8").delta("#fff") // 0.1447411
-colord("#afafaf").delta("#b4b4b4") // 0.0138414
+colord("#3296fa").delta("#197dc8") // 0.099
+colord("#faf0c8").delta("#fff") // 0.148
+colord("#afafaf").delta("#b4b4b4") // 0.014
 colord("#000").delta("#fff") // 1.0
 ```
 

--- a/README.md
+++ b/README.md
@@ -842,7 +842,7 @@ colord("hwb(210 0% 60% / 50%)").toHex(); // "#00336680"
 </details>
 
 <details>
-  <summary><b><code>lab</code> (CIE LAB color space)</b> <i>0.9 KB</i></summary>
+  <summary><b><code>lab</code> (CIE LAB color space)</b> <i>1.5 KB</i></summary>
 
 Adds support of [CIE LAB](https://en.wikipedia.org/wiki/CIELAB_color_space) color model. The conversion logic is ported from [CSS Color Module Level 4 Specification](https://www.w3.org/TR/css-color-4/#color-conversion-code).
 
@@ -856,6 +856,9 @@ extend([labPlugin]);
 
 colord({ l: 53.24, a: 80.09, b: 67.2 }).toHex(); // "#ff0000"
 colord("#ffffff").toLab(); // { l: 100, a: 0, b: 0, alpha: 1 }
+
+colord("#afafaf").delta("#b4b4b4") // 0.014
+colord("#000").delta("#fff") // 1.0
 ```
 
 </details>

--- a/package.json
+++ b/package.json
@@ -166,7 +166,7 @@
     },
     {
       "path": "dist/plugins/lab.mjs",
-      "limit": "1 KB"
+      "limit": "1.5 KB"
     },
     {
       "path": "dist/plugins/lch.mjs",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -13,13 +13,3 @@ export const ANGLE_UNITS: Record<string, number> = {
   turn: 360,
   rad: 360 / (Math.PI * 2),
 };
-
-/**
- * Radians to degrees multiplier.
- */
-export const rad2deg = 180 / Math.PI;
-
-/**
- * Degrees to radiants multiplier.
- */
-export const deg2rad = Math.PI / 180;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -13,3 +13,13 @@ export const ANGLE_UNITS: Record<string, number> = {
   turn: 360,
   rad: 360 / (Math.PI * 2),
 };
+
+/**
+ * Radians to degrees multiplier.
+ */
+export const rad2deg = 180 / Math.PI;
+
+/**
+ * Degrees to radiants multiplier.
+ */
+export const deg2rad = Math.PI / 180;

--- a/src/get/getPerceivedDifference.ts
+++ b/src/get/getPerceivedDifference.ts
@@ -1,0 +1,123 @@
+import { rad2deg, deg2rad } from "../constants";
+import { LabaColor } from "../types";
+
+/**
+ * kl - grafic arts = 1; textiles = 2;
+ * kl - unity factor;
+ * kh - weighting factor;
+ */
+interface Options {
+  kl: 1 | 2;
+  kc: number;
+  kh: number;
+}
+
+/**
+ * Calculates the perceived color difference according to [Delta E2000](https://en.wikipedia.org/wiki/Color_difference#CIEDE2000).
+ *
+ * ΔE - (Delta E, dE) The measure of change in visual perception of two given colors.
+ *
+ * Delta E is a metric for understanding how the human eye perceives color difference.
+ * The term delta comes from mathematics, meaning change in a variable or function.
+ * The suffix E references the German word Empfindung, which broadly means sensation.
+ *
+ * On a typical scale, the Delta E value will range from 0 to 100.
+ *
+ * | Delta E | Perception                             |
+ * |---------|----------------------------------------|
+ * | <= 1.0	 | Not perceptible by human eyes          |
+ * | 1 - 2	 | Perceptible through close observation  |
+ * | 2 - 10	 | Perceptible at a glance                |
+ * | 11 - 49 | Colors are more similar than opposite  |
+ * | 100	   | Colors are exact opposite              |
+ *
+ * [Source](http://www.brucelindbloom.com/index.html?Eqn_DeltaE_CIE2000.html)
+ * [Read about Delta E](https://zschuessler.github.io/DeltaE/learn/#toc-delta-e-2000)
+ */
+export function deltaE00(
+  color1: LabaColor,
+  color2: LabaColor,
+  options: Partial<Options> = {}
+): number {
+  const { kl = 1, kc = 1, kh = 1 } = options;
+
+  const { l: l1, a: a1, b: b1 } = color1;
+  const { l: l2, a: a2, b: b2 } = color2;
+
+  // dc -> delta c;
+  // ml -> median l;
+  const c1 = (a1 ** 2 + b1 ** 2) ** 0.5;
+  const c2 = (a2 ** 2 + b2 ** 2) ** 0.5;
+  const mc = (c1 + c2) / 2;
+  const ml = (l1 + l2) / 2;
+
+  // reuse
+  const c7 = mc ** 7;
+  const g = 0.5 * (1 - (c7 / (c7 + 25 ** 7)) ** 0.5);
+
+  const a11 = a1 * (1 + g);
+  const a22 = a2 * (1 + g);
+
+  const c11 = (a11 ** 2 + b1 ** 2) ** 0.5;
+  const c22 = (a22 ** 2 + b2 ** 2) ** 0.5;
+  const mc1 = (c11 + c22) / 2;
+
+  let h1 = a11 === 0 && b1 === 0 ? 0 : Math.atan2(b1, a11) * rad2deg;
+  let h2 = a22 === 0 && b2 === 0 ? 0 : Math.atan2(b2, a22) * rad2deg;
+
+  if (h1 < 0) {
+    h1 += 360;
+  }
+
+  if (h2 < 0) {
+    h2 += 360;
+  }
+
+  let dh = h2 - h1;
+  const dhAbs = Math.abs(h2 - h1);
+
+  if (dhAbs > 180 && h2 <= h1) {
+    dh += 360;
+  } else if (dhAbs > 180 && h2 > h1) {
+    dh -= 360;
+  }
+
+  let H = h1 + h2;
+
+  if (dhAbs <= 180) {
+    H /= 2;
+  } else {
+    if (h1 + h2 < 360) {
+      H = (H + 360) / 2;
+    } else {
+      H = (H - 360) / 2;
+    }
+  }
+
+  const T =
+    1 -
+    0.17 * Math.cos(deg2rad * (H - 30)) +
+    0.24 * Math.cos(deg2rad * 2 * H) +
+    0.32 * Math.cos(deg2rad * (3 * H + 6)) -
+    0.2 * Math.cos(deg2rad * (4 * H - 63));
+
+  const dL = l2 - l1;
+  const dC = c22 - c11;
+  const dH = 2 * Math.sin((deg2rad * dh) / 2) * (c11 * c22) ** 0.5;
+
+  const sL = 1 + (0.015 * (ml - 50) ** 2) / (20 + (ml - 50) ** 2) ** 0.5;
+  const sC = 1 + 0.045 * mc1;
+  const sH = 1 + 0.015 * mc1 * T;
+
+  const dTheta = 30 * Math.exp(-1 * ((H - 275) / 25) ** 2);
+  const Rc = 2 * (c7 / (c7 + 25 ** 7)) ** 0.5;
+  const Rt = -Rc * Math.sin(deg2rad * 2 * dTheta);
+
+  return (
+    ((dL / kl / sL) ** 2 +
+      (dC / kc / sC) ** 2 +
+      (dH / kh / sH) ** 2 +
+      (Rt * dC * dH) / (kc * sC * kh * sH)) **
+    0.5
+  );
+}

--- a/src/get/getPerceivedDifference.ts
+++ b/src/get/getPerceivedDifference.ts
@@ -2,17 +2,6 @@ import { rad2deg, deg2rad } from "../constants";
 import { LabaColor } from "../types";
 
 /**
- * kl - grafic arts = 1; textiles = 2;
- * kl - unity factor;
- * kh - weighting factor;
- */
-export interface DeltaE00Options {
-  kl: 1 | 2;
-  kc: number;
-  kh: number;
-}
-
-/**
  * Calculates the perceived color difference according to [Delta E2000](https://en.wikipedia.org/wiki/Color_difference#CIEDE2000).
  *
  * ΔE - (Delta E, dE) The measure of change in visual perception of two given colors.
@@ -34,12 +23,13 @@ export interface DeltaE00Options {
  * [Source](http://www.brucelindbloom.com/index.html?Eqn_DeltaE_CIE2000.html)
  * [Read about Delta E](https://zschuessler.github.io/DeltaE/learn/#toc-delta-e-2000)
  */
-export function getDeltaE00(
-  color1: LabaColor,
-  color2: LabaColor,
-  options: Partial<DeltaE00Options> = {}
-): number {
-  const { kl = 1, kc = 1, kh = 1 } = options;
+export function getDeltaE00(color1: LabaColor, color2: LabaColor): number {
+  /**
+   * kl - grafic arts = 1; textiles = 2;
+   * kl - unity factor;
+   * kh - weighting factor;
+   */
+  const [kl, kc, kh] = [1, 1, 1];
 
   const { l: l1, a: a1, b: b1 } = color1;
   const { l: l2, a: a2, b: b2 } = color2;

--- a/src/get/getPerceivedDifference.ts
+++ b/src/get/getPerceivedDifference.ts
@@ -6,7 +6,7 @@ import { LabaColor } from "../types";
  * kl - unity factor;
  * kh - weighting factor;
  */
-interface Options {
+export interface DeltaE00Options {
   kl: 1 | 2;
   kc: number;
   kh: number;
@@ -37,7 +37,7 @@ interface Options {
 export function deltaE00(
   color1: LabaColor,
   color2: LabaColor,
-  options: Partial<Options> = {}
+  options: Partial<DeltaE00Options> = {}
 ): number {
   const { kl = 1, kc = 1, kh = 1 } = options;
 

--- a/src/get/getPerceivedDifference.ts
+++ b/src/get/getPerceivedDifference.ts
@@ -34,7 +34,7 @@ export interface DeltaE00Options {
  * [Source](http://www.brucelindbloom.com/index.html?Eqn_DeltaE_CIE2000.html)
  * [Read about Delta E](https://zschuessler.github.io/DeltaE/learn/#toc-delta-e-2000)
  */
-export function deltaE00(
+export function getDeltaE00(
   color1: LabaColor,
   color2: LabaColor,
   options: Partial<DeltaE00Options> = {}

--- a/src/get/getPerceivedDifference.ts
+++ b/src/get/getPerceivedDifference.ts
@@ -1,4 +1,3 @@
-import { rad2deg, deg2rad } from "../constants";
 import { LabaColor } from "../types";
 
 /**
@@ -14,25 +13,21 @@ import { LabaColor } from "../types";
  *
  * | Delta E | Perception                             |
  * |---------|----------------------------------------|
- * | <= 1.0	 | Not perceptible by human eyes          |
- * | 1 - 2	 | Perceptible through close observation  |
- * | 2 - 10	 | Perceptible at a glance                |
+ * | <= 1.0  | Not perceptible by human eyes          |
+ * | 1 - 2   | Perceptible through close observation  |
+ * | 2 - 10  | Perceptible at a glance                |
  * | 11 - 49 | Colors are more similar than opposite  |
- * | 100	   | Colors are exact opposite              |
+ * | 100     | Colors are exact opposite              |
  *
  * [Source](http://www.brucelindbloom.com/index.html?Eqn_DeltaE_CIE2000.html)
  * [Read about Delta E](https://zschuessler.github.io/DeltaE/learn/#toc-delta-e-2000)
  */
 export function getDeltaE00(color1: LabaColor, color2: LabaColor): number {
-  /**
-   * kl - grafic arts = 1; textiles = 2;
-   * kl - unity factor;
-   * kh - weighting factor;
-   */
-  const [kl, kc, kh] = [1, 1, 1];
-
   const { l: l1, a: a1, b: b1 } = color1;
   const { l: l2, a: a2, b: b2 } = color2;
+
+  const rad2deg = 180 / Math.PI;
+  const deg2rad = Math.PI / 180;
 
   // dc -> delta c;
   // ml -> median l;
@@ -55,13 +50,8 @@ export function getDeltaE00(color1: LabaColor, color2: LabaColor): number {
   let h1 = a11 === 0 && b1 === 0 ? 0 : Math.atan2(b1, a11) * rad2deg;
   let h2 = a22 === 0 && b2 === 0 ? 0 : Math.atan2(b2, a22) * rad2deg;
 
-  if (h1 < 0) {
-    h1 += 360;
-  }
-
-  if (h2 < 0) {
-    h2 += 360;
-  }
+  if (h1 < 0) h1 += 360;
+  if (h2 < 0) h2 += 360;
 
   let dh = h2 - h1;
   const dhAbs = Math.abs(h2 - h1);
@@ -98,6 +88,10 @@ export function getDeltaE00(color1: LabaColor, color2: LabaColor): number {
   const dTheta = 30 * Math.exp(-1 * ((H - 275) / 25) ** 2);
   const Rc = 2 * (c7 / (c7 + 25 ** 7)) ** 0.5;
   const Rt = -Rc * Math.sin(deg2rad * 2 * dTheta);
+
+  const kl = 1; // 1 for graphic arts, 2 for textiles
+  const kc = 1; // unity factor
+  const kh = 1; // weighting factor
 
   return (
     ((dL / kl / sL) ** 2 +

--- a/src/get/getPerceivedDifference.ts
+++ b/src/get/getPerceivedDifference.ts
@@ -77,11 +77,7 @@ export function getDeltaE00(color1: LabaColor, color2: LabaColor): number {
   if (dhAbs <= 180) {
     H /= 2;
   } else {
-    if (h1 + h2 < 360) {
-      H = (H + 360) / 2;
-    } else {
-      H = (H - 360) / 2;
-    }
+    H = (h1 + h2 < 360 ? H + 360 : H - 360) / 2;
   }
 
   const T =

--- a/src/plugins/lab.ts
+++ b/src/plugins/lab.ts
@@ -2,7 +2,7 @@ import { LabaColor, AnyColor } from "../types";
 import { Plugin } from "../extend";
 import { parseLaba, roundLaba, rgbaToLaba } from "../colorModels/lab";
 import { getDeltaE00, DeltaE00Options } from "../get/getPerceivedDifference";
-import { clamp } from "../helpers";
+import { clamp, round } from "../helpers";
 
 declare module "../colord" {
   interface Colord {
@@ -31,7 +31,8 @@ const labPlugin: Plugin = (ColordClass, parsers): void => {
 
   ColordClass.prototype.delta = function (color, options) {
     const compared = color instanceof ColordClass ? color : new ColordClass(color);
-    return clamp(getDeltaE00(this.toLab(), compared.toLab(), options) / 100);
+    const delta = getDeltaE00(this.toLab(), compared.toLab(), options) / 100;
+    return clamp(round(delta, 3));
   };
 
   parsers.object.push([parseLaba, "lab"]);

--- a/src/plugins/lab.ts
+++ b/src/plugins/lab.ts
@@ -8,15 +8,16 @@ declare module "../colord" {
   interface Colord {
     /**
      * Converts a color to CIELAB color space and returns an object.
-     * The object always includes `alpha` value [0—1].
+     * The object always includes `alpha` value [0, 1].
      */
     toLab(): LabaColor;
 
     /**
      * Calculates the perceived color difference for two colors according to
      * [Delta E2000](https://en.wikipedia.org/wiki/Color_difference#CIEDE2000).
+     * Returns a value in [0, 1] range.
      */
-    delta(color: AnyColor | Colord): number;
+    delta(color?: AnyColor | Colord): number;
   }
 }
 
@@ -29,7 +30,7 @@ const labPlugin: Plugin = (ColordClass, parsers): void => {
     return roundLaba(rgbaToLaba(this.rgba));
   };
 
-  ColordClass.prototype.delta = function (color) {
+  ColordClass.prototype.delta = function (color = "#FFF") {
     const compared = color instanceof ColordClass ? color : new ColordClass(color);
     const delta = getDeltaE00(this.toLab(), compared.toLab()) / 100;
     return clamp(round(delta, 3));

--- a/src/plugins/lab.ts
+++ b/src/plugins/lab.ts
@@ -1,7 +1,7 @@
 import { LabaColor, AnyColor } from "../types";
 import { Plugin } from "../extend";
 import { parseLaba, roundLaba, rgbaToLaba } from "../colorModels/lab";
-import { deltaE00, DeltaE00Options } from "../get/getPerceivedDifference";
+import { getDeltaE00, DeltaE00Options } from "../get/getPerceivedDifference";
 import { clamp } from "../helpers";
 
 declare module "../colord" {
@@ -31,7 +31,7 @@ const labPlugin: Plugin = (ColordClass, parsers): void => {
 
   ColordClass.prototype.delta = function (color, options) {
     const compared = color instanceof ColordClass ? color : new ColordClass(color);
-    return clamp(deltaE00(this.toLab(), compared.toLab(), options) / 100);
+    return clamp(getDeltaE00(this.toLab(), compared.toLab(), options) / 100);
   };
 
   parsers.object.push([parseLaba, "lab"]);

--- a/src/plugins/lab.ts
+++ b/src/plugins/lab.ts
@@ -1,7 +1,7 @@
 import { LabaColor, AnyColor } from "../types";
 import { Plugin } from "../extend";
 import { parseLaba, roundLaba, rgbaToLaba } from "../colorModels/lab";
-import { getDeltaE00, DeltaE00Options } from "../get/getPerceivedDifference";
+import { getDeltaE00 } from "../get/getPerceivedDifference";
 import { clamp, round } from "../helpers";
 
 declare module "../colord" {
@@ -16,7 +16,7 @@ declare module "../colord" {
      * Calculates the perceived color difference for two colors according to
      * [Delta E2000](https://en.wikipedia.org/wiki/Color_difference#CIEDE2000).
      */
-    delta(color: AnyColor | Colord, options?: Partial<DeltaE00Options>): number;
+    delta(color: AnyColor | Colord): number;
   }
 }
 
@@ -29,9 +29,9 @@ const labPlugin: Plugin = (ColordClass, parsers): void => {
     return roundLaba(rgbaToLaba(this.rgba));
   };
 
-  ColordClass.prototype.delta = function (color, options) {
+  ColordClass.prototype.delta = function (color) {
     const compared = color instanceof ColordClass ? color : new ColordClass(color);
-    const delta = getDeltaE00(this.toLab(), compared.toLab(), options) / 100;
+    const delta = getDeltaE00(this.toLab(), compared.toLab()) / 100;
     return clamp(round(delta, 3));
   };
 

--- a/src/plugins/lab.ts
+++ b/src/plugins/lab.ts
@@ -1,7 +1,8 @@
 import { LabaColor, AnyColor } from "../types";
 import { Plugin } from "../extend";
 import { parseLaba, roundLaba, rgbaToLaba } from "../colorModels/lab";
-import { deltaE00 } from "../get/getPerceivedDifference";
+import { deltaE00, DeltaE00Options } from "../get/getPerceivedDifference";
+import { clamp } from "../helpers";
 
 declare module "../colord" {
   interface Colord {
@@ -15,7 +16,7 @@ declare module "../colord" {
      * Calculates the perceived color difference for two colors according to
      * [Delta E2000](https://en.wikipedia.org/wiki/Color_difference#CIEDE2000).
      */
-    deltaE00(color: AnyColor | Colord): number;
+    delta(color: AnyColor | Colord, options?: Partial<DeltaE00Options>): number;
   }
 }
 
@@ -28,9 +29,9 @@ const labPlugin: Plugin = (ColordClass, parsers): void => {
     return roundLaba(rgbaToLaba(this.rgba));
   };
 
-  ColordClass.prototype.deltaE00 = function (color) {
+  ColordClass.prototype.delta = function (color, options) {
     const compared = color instanceof ColordClass ? color : new ColordClass(color);
-    return deltaE00(this.toLab(), compared.toLab());
+    return clamp(deltaE00(this.toLab(), compared.toLab(), options) / 100);
   };
 
   parsers.object.push([parseLaba, "lab"]);

--- a/tests/plugins.test.ts
+++ b/tests/plugins.test.ts
@@ -8,7 +8,6 @@ import lchPlugin from "../src/plugins/lch";
 import mixPlugin from "../src/plugins/mix";
 import namesPlugin from "../src/plugins/names";
 import xyzPlugin from "../src/plugins/xyz";
-import { round } from "../src/helpers";
 
 describe("a11y", () => {
   extend([a11yPlugin]);
@@ -210,10 +209,10 @@ describe("lab", () => {
      *
      * After migrating the state to XYZ or handling the rounding problem, tests using other color models should be added.
      */
-    expect(round(colord("#3296fa").delta("#197dc8"), 7)).toBe(0.0989261);
-    expect(round(colord("#faf0c8").delta("#fff"), 7)).toBe(0.1447411);
-    expect(round(colord("#afafaf").delta("#b4b4b4"), 7)).toBe(0.0138414);
-    expect(round(colord("#000").delta("#fff"), 5)).toBe(1.0);
+    expect(colord("#3296fa").delta("#197dc8")).toBe(0.099);
+    expect(colord("#faf0c8").delta("#fff")).toBe(0.145);
+    expect(colord("#afafaf").delta("#b4b4b4")).toBe(0.014);
+    expect(colord("#000").delta("#fff")).toBe(1);
   });
 
   it("Supported by `getFormat`", () => {

--- a/tests/plugins.test.ts
+++ b/tests/plugins.test.ts
@@ -213,6 +213,10 @@ describe("lab", () => {
     expect(colord("#faf0c8").delta("#fff")).toBe(0.145);
     expect(colord("#afafaf").delta("#b4b4b4")).toBe(0.014);
     expect(colord("#000").delta("#fff")).toBe(1);
+    expect(colord("#000").delta("#c8cdd7")).toBe(0.737);
+    expect(colord("#c8cdd7").delta("#000")).toBe(0.737);
+    expect(colord("#f4f4f4").delta("#fafafa")).toBe(0.012);
+    expect(colord("#f4f4f4").delta("#f4f4f4")).toBe(0);
   });
 
   it("Supported by `getFormat`", () => {

--- a/tests/plugins.test.ts
+++ b/tests/plugins.test.ts
@@ -8,6 +8,7 @@ import lchPlugin from "../src/plugins/lch";
 import mixPlugin from "../src/plugins/mix";
 import namesPlugin from "../src/plugins/names";
 import xyzPlugin from "../src/plugins/xyz";
+import { round } from "../src/helpers";
 
 describe("a11y", () => {
   extend([a11yPlugin]);
@@ -197,6 +198,19 @@ describe("lab", () => {
     expect(colord("#aabbcc").toLab()).toMatchObject({ l: 74.97, a: -3.4, b: -10.7, alpha: 1 });
     expect(colord("#33221180").toLab()).toMatchObject({ l: 15.05, a: 6.68, b: 14.59, alpha: 0.5 });
     expect(colord("#d53987").toLab()).toMatchObject({ l: 50.93, a: 64.96, b: -6.38, alpha: 1 });
+  });
+
+  it("Calculates the the perceived color difference", () => {
+    // test results: https://cielab.xyz/colordiff.php
+    expect(
+      round(colord({ l: 28.27, a: 50.61, b: 42.13 }).deltaE00({ l: 33.56, a: -6.01, b: 40.81 }), 5)
+    ).toBe(35.65174);
+    expect(round(colord({ l: 28, a: 50, b: 64 }).deltaE00({ l: 33, a: -10, b: 98 }), 5)).toBe(
+      37.81158
+    );
+    expect(round(colord({ l: 59, a: -25, b: -50 }).deltaE00({ l: 78, a: -36, b: 29 }), 5)).toBe(
+      48.25889
+    );
   });
 
   it("Supported by `getFormat`", () => {

--- a/tests/plugins.test.ts
+++ b/tests/plugins.test.ts
@@ -201,16 +201,19 @@ describe("lab", () => {
   });
 
   it("Calculates the the perceived color difference", () => {
-    // test results: https://cielab.xyz/colordiff.php
-    expect(
-      round(colord({ l: 28.27, a: 50.61, b: 42.13 }).deltaE00({ l: 33.56, a: -6.01, b: 40.81 }), 5)
-    ).toBe(35.65174);
-    expect(round(colord({ l: 28, a: 50, b: 64 }).deltaE00({ l: 33, a: -10, b: 98 }), 5)).toBe(
-      37.81158
-    );
-    expect(round(colord({ l: 59, a: -25, b: -50 }).deltaE00({ l: 78, a: -36, b: 29 }), 5)).toBe(
-      48.25889
-    );
+    /**
+     * Test resuls: https://cielab.xyz/colordiff.php
+     *
+     * All tests done using RGB.
+     * Inner state is RGB, it is discrete thus all model transformations become discrete
+     * and some accuracy is lost.
+     *
+     * After migrating the state to XYZ or handling the rounding problem, tests using other color models should be added.
+     */
+    expect(round(colord("#3296fa").delta("#197dc8"), 7)).toBe(0.0989261);
+    expect(round(colord("#faf0c8").delta("#fff"), 7)).toBe(0.1447411);
+    expect(round(colord("#afafaf").delta("#b4b4b4"), 7)).toBe(0.0138414);
+    expect(round(colord("#000").delta("#fff"), 5)).toBe(1.0);
   });
 
   it("Supported by `getFormat`", () => {


### PR DESCRIPTION
There is the `DeltaE2000` implementation. It works correctly, the results were tested [here](https://cielab.xyz/colordiff.php).

But we have a problem. Despite the calculations are correct, we have wrong values, just a bit, but always wrong. I spend a lot of time trying to find out why and I found the problem. I was testing `LAB / LAB` comparison and I found out that if you create `Colord` instance using `LAB` color, and get `LAB` object back - values won't be the same.

Here the test that is unsuccessful:

```js
expect(round(colord({ l: 28, a: 50, b: 64 })
  .deltaE00({ l: 33, a: -10, b: 98 }), 5))
   .toBe(37.81158); // result is 35.65174
```

I took these `LAB` values to get `LAB` object back and go this:

```js
colord({ l: 28, a: 50, b: 64 }) // -> { l: 28.27, a: 50.61, b: 42.13 }
colord({ l: 33, a: -10, b: 98 }) // -> { l: 33.56, a: -6.01, b: 40.81 }
```

Now testing these values I have successfull test case:

```js
expect(round(colord({ l: 28.27, a: 50.61, b: 42.13 })
  .deltaE00({ l: 33.56, a: -6.01, b: 40.81 }), 5))
  .toBe(35.65174);
```

I think the problem is with discrete values of the `RGB` color we use to store the color state. Having discrete values as the main state we have discrete values for all the color models and we lost some accuracy.

If I do something wrong, please tell me, I don't quite sure if I am doing everything correct. In case if the problem is real, I think we should return integer `RGB` values to the end consumer and use float values for model transformations.

P.S. The docs is not ready yet in this PR. Will do, but I don't think we need them yet.
