### PR TITLE
feat(colord): add `toBase10`

### DIFF
--- a/src/colord.ts
+++ b/src/colord.ts
@@ -51,9 +51,20 @@ export class Colord {
 
   /**
    * Same as calling `brightness() >= 0.5`.
-   * */
+   */
   public isLight(): boolean {
     return getBrightness(this.rgba) >= 0.5;
+  }
+
+  /**
+   * Returns the base 10 representation of a color.
+   * When the alpha channel value of the color is less than 1,
+   * it outputs RGBA (32bits) instead of RGB (24bits).
+   */
+  public toBase10(): number {
+    return this.rgba.a < 1
+      ? (this.rgba.r << 24) + (this.rgba.g << 16) + (this.rgba.b << 8) + round(this.rgba.a * 255)
+      : (this.rgba.r << 16) + (this.rgba.g << 8) + this.rgba.b;
   }
 
   /**

--- a/tests/colord.test.ts
+++ b/tests/colord.test.ts
@@ -23,8 +23,10 @@ it("Converts between HEX, RGB, HSL and HSV color models properly", () => {
 });
 
 it("Parses and converts a color", () => {
+  const base10 = parseInt((lime.hex as string).slice(1), 16);
   for (const format in lime) {
     const instance = colord(lime[format] as AnyColor);
+    expect(instance.toBase10()).toBe(base10);
     expect(instance.toHex()).toBe(lime.hex);
     expect(instance.toRgb()).toMatchObject(lime.rgba);
     expect(instance.toRgbString()).toBe(lime.rgbString);


### PR DESCRIPTION
Fixes #104

I chose not to add `src/colorModels/base10.ts` (and therefore support numbers as input) because it would be impossible to properly determine whether a number is RGB or RGBA, so the solution I reached was to just add a method.

This addition would also prove very helpful for APIs that natively use (and support) base10 numbers, such as Discord.
