### PR TITLE
REDOS Patch

### DIFF
--- a/src/colorModels/cmykString.ts
+++ b/src/colorModels/cmykString.ts
@@ -1,7 +1,8 @@
 import { RgbaColor } from "../types";
 import { clampCmyka, cmykaToRgba, rgbaToCmyka, roundCmyka } from "./cmyk";
 
-const cmykMatcher = /^device-cmyk\(\s*([+-]?\d*\.?\d+)(%)?\s+([+-]?\d*\.?\d+)(%)?\s+([+-]?\d*\.?\d+)(%)?\s+([+-]?\d*\.?\d+)(%)?\s*(?:\/\s*([+-]?\d*\.?\d+)(%)?\s*)?\)$/i;
+const cmykMatcher = /^device-cmyk\(\s*([+-]?\d{1,3}(?:\.\d+)?)%\s+([+-]?\d{1,3}(?:\.\d+)?)%\s+([+-]?\d{1,3}(?:\.\d+)?)%\s+([+-]?\d{1,3}(?:\.\d+)?)%(?:\s*\/\s*([+-]?\d{1,3}(?:\.\d+)?)%)?\)$/i;
+
 
 /**
  * Parses a valid CMYK CSS color function/string

--- a/src/colorModels/hslString.ts
+++ b/src/colorModels/hslString.ts
@@ -4,11 +4,11 @@ import { clampHsla, rgbaToHsla, hslaToRgba, roundHsla } from "./hsl";
 
 // Functional syntax
 // hsl( <hue>, <percentage>, <percentage>, <alpha-value>? )
-const commaHslaMatcher = /^hsla?\(\s*([+-]?\d*\.?\d+)(deg|rad|grad|turn)?\s*,\s*([+-]?\d*\.?\d+)%\s*,\s*([+-]?\d*\.?\d+)%\s*(?:,\s*([+-]?\d*\.?\d+)(%)?\s*)?\)$/i;
+const commaHslaMatcher = /^hsla?\(\s*([+-]?\d{1,3})(deg|rad|grad|turn)?\s*,\s*([+-]?\d{1,3})%\s*,\s*([+-]?\d{1,3})%\s*(?:,\s*([+-]?\d*\.?\d{1,3})(%)?\s*)?\)$/i;
 
 // Whitespace syntax
 // hsl( <hue> <percentage> <percentage> [ / <alpha-value> ]? )
-const spaceHslaMatcher = /^hsla?\(\s*([+-]?\d*\.?\d+)(deg|rad|grad|turn)?\s+([+-]?\d*\.?\d+)%\s+([+-]?\d*\.?\d+)%\s*(?:\/\s*([+-]?\d*\.?\d+)(%)?\s*)?\)$/i;
+const spaceHslaMatcher = /^hsla?\(\s*([+-]?\d{1,3}(?:\.\d+)?)\s*(deg|rad|grad|turn)?\s+([+-]?\d{1,3}(?:\.\d+)?)%\s+([+-]?\d{1,3}(?:\.\d+)?)%\s*(?:\/\s*([+-]?\d{1,3}(?:\.\d+)?)%)?\)$/i;
 
 /**
  * Parses a valid HSL[A] CSS color function/string

--- a/src/colorModels/hwbString.ts
+++ b/src/colorModels/hwbString.ts
@@ -4,7 +4,7 @@ import { clampHwba, rgbaToHwba, hwbaToRgba, roundHwba } from "./hwb";
 
 // The only valid HWB syntax
 // hwb( <hue> <percentage> <percentage> [ / <alpha-value> ]? )
-const hwbaMatcher = /^hwb\(\s*([+-]?\d*\.?\d+)(deg|rad|grad|turn)?\s+([+-]?\d*\.?\d+)%\s+([+-]?\d*\.?\d+)%\s*(?:\/\s*([+-]?\d*\.?\d+)(%)?\s*)?\)$/i;
+const hwbaMatcher = /^hwb\(\s*([+-]?\d{1,3}(?:\.\d+)?)\s*(deg|rad|grad|turn)?\s+([+-]?\d{1,3}(?:\.\d+)?)%\s+([+-]?\d{1,3}(?:\.\d+)?)%\s*(?:\/\s*([+-]?\d{1,3}(?:\.\d+)?)%)?\)$/i;
 
 /**
  * Parses a valid HWB[A] CSS color function/string

--- a/src/colorModels/lchString.ts
+++ b/src/colorModels/lchString.ts
@@ -4,7 +4,7 @@ import { clampLcha, rgbaToLcha, lchaToRgba, roundLcha } from "./lch";
 
 // The only valid LCH syntax
 // lch() = lch( <percentage> <number> <hue> [ / <alpha-value> ]? )
-const lchaMatcher = /^lch\(\s*([+-]?\d*\.?\d+)%\s+([+-]?\d*\.?\d+)\s+([+-]?\d*\.?\d+)(deg|rad|grad|turn)?\s*(?:\/\s*([+-]?\d*\.?\d+)(%)?\s*)?\)$/i;
+const lchaMatcher = /^lch\(\s*([+-]?\d{1,3}(?:\.\d+)?)%\s+([+-]?\d{1,3}(?:\.\d+)?)\s+([+-]?\d{1,3}(?:\.\d+)?)\s*(deg|rad|grad|turn)?\s*(?:\/\s*([+-]?\d{1,3}(?:\.\d+)?)%)?\)$/i;
 
 /**
  * Parses a valid LCH CSS color function/string

--- a/src/colorModels/rgbString.ts
+++ b/src/colorModels/rgbString.ts
@@ -4,12 +4,12 @@ import { roundRgba, clampRgba } from "./rgb";
 // Functional syntax
 // rgb( <percentage>#{3} , <alpha-value>? )
 // rgb( <number>#{3} , <alpha-value>? )
-const commaRgbaMatcher = /^rgba?\(\s*([+-]?\d*\.?\d+)(%)?\s*,\s*([+-]?\d*\.?\d+)(%)?\s*,\s*([+-]?\d*\.?\d+)(%)?\s*(?:,\s*([+-]?\d*\.?\d+)(%)?\s*)?\)$/i;
+const commaRgbaMatcher = /^rgba?\(\s*([+-]?\d{1,3}(?:\.\d+)?)%\s*,\s*([+-]?\d{1,3}(?:\.\d+)?)%\s*,\s*([+-]?\d{1,3}(?:\.\d+)?)%\s*(?:,\s*([+-]?\d{1,3}(?:\.\d+)?)%)?\)$/i;
 
 // Whitespace syntax
 // rgb( <percentage>{3} [ / <alpha-value> ]? )
 // rgb( <number>{3} [ / <alpha-value> ]? )
-const spaceRgbaMatcher = /^rgba?\(\s*([+-]?\d*\.?\d+)(%)?\s+([+-]?\d*\.?\d+)(%)?\s+([+-]?\d*\.?\d+)(%)?\s*(?:\/\s*([+-]?\d*\.?\d+)(%)?\s*)?\)$/i;
+const spaceRgbaMatcher = /^rgba?\(\s*([+-]?\d{1,3}(?:\.\d+)?)%\s+([+-]?\d{1,3}(?:\.\d+)?)%\s+([+-]?\d{1,3}(?:\.\d+)?)%\s*(?:\/\s*([+-]?\d{1,3}(?:\.\d+)?)%)?\)$/i;
 
 /**
  * Parses a valid RGB[A] CSS color function/string


### PR DESCRIPTION
Test Environment:
Apple M1 macbook air, 2020 (ventura 13.3.1)

node module
name : colord : v2.9

node js
version : v18.16.0

2023 Jul 10

Subject: ReDoS Vulnerability Report in the "colord" Module

Dear colord team,
I am writing to report a potential ReDoS (Regular Expression Denial of Service) vulnerability in your "colord" module. It has come to my attention that the current regex implementation for parsing hsla values in the module is susceptible to excessive backtracking, leading to potential DoS attacks.

This vulnerability can be exploited when there is an imbalance in parentheses, which results in excessive backtracking and subsequently increases the CPU load and processing time significantly. This vulnerability can be triggered using the following 

Here is a simple PoC code to demonstrate the issue:

npm i colord
import { colord } from "colord";
colord( [same value as above] ).isLight();

The ReDoS vulnerability can also be reproduced on your website at https://colord.omgovich.ru/ by inserting the same input.
To mitigate this issue, I suggest modifying the regular expression as follows:

This modification adds a limit to the number of digits, thereby preventing the ReDoS vulnerability from occurring.
I believe it is crucial to address this issue promptly to ensure the security of your module for all users. Please let me know if you need any further information or assistance with this matter.
