### PR TITLE
Ship LICENSE.md in package and add SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,17 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+Please report security vulnerabilities privately through GitHub's [private vulnerability reporting](https://github.com/omgovich/colord/security/advisories/new) form.
+
+Include:
+
+- A description of the issue and its potential impact
+- Steps to reproduce, a proof of concept, or a code snippet
+- The affected version(s) of colord
+
+Please do not open public GitHub issues for security vulnerabilities.
+
+## Supported Versions
+
+Security fixes are applied to the latest released version on the `master` branch.

--- a/package.json
+++ b/package.json
@@ -100,7 +100,8 @@
   },
   "files": [
     "*.{js,mjs,ts,map}",
-    "plugins/*.{js,mjs,ts,map}"
+    "plugins/*.{js,mjs,ts,map}",
+    "LICENSE.md"
   ],
   "types": "index.d.ts",
   "scripts": {


### PR DESCRIPTION
## Summary
- Add `LICENSE.md` to the `files` array in `package.json` so it's explicitly included in the published tarball — helps SBOM tooling detect the license. Closes #128.
- Add `SECURITY.md` pointing to GitHub's private vulnerability reporting form for responsible disclosure. Closes #108.

## Test plan
- [x] `npm pack --dry-run` lists `LICENSE.md` in the tarball contents
- [x] `SECURITY.md` renders on the repo's Security tab and the "Report a vulnerability" link resolves

🤖 Generated with [Claude Code](https://claude.com/claude-code)