### PR TITLE
fix: keep the hue within [0, 360) in every color model

### DIFF
--- a/src/colorModels/hsl.ts
+++ b/src/colorModels/hsl.ts
@@ -1,6 +1,6 @@
 import { InputObject, RgbaColor, HslaColor, HsvaColor } from "../types";
 import { ALPHA_PRECISION } from "../constants";
-import { clamp, clampHue, round, isPresent } from "../helpers";
+import { clamp, clampHue, round, roundHue, isPresent } from "../helpers";
 import { hsvaToRgba, rgbaToHsva } from "./hsv";
 
 export const clampHsla = (hsla: HslaColor): HslaColor => ({
@@ -11,9 +11,7 @@ export const clampHsla = (hsla: HslaColor): HslaColor => ({
 });
 
 export const roundHsla = (hsla: HslaColor): HslaColor => ({
-  // Keep the hue in [0, 360); rounding can otherwise produce 360 (e.g. for
-  // near-360 reds), which breaks round-tripping since parsing normalizes 360 to 0.
-  h: round(hsla.h) % 360,
+  h: roundHue(hsla.h),
   s: round(hsla.s),
   l: round(hsla.l),
   a: round(hsla.a, ALPHA_PRECISION),

--- a/src/colorModels/hsl.ts
+++ b/src/colorModels/hsl.ts
@@ -11,7 +11,9 @@ export const clampHsla = (hsla: HslaColor): HslaColor => ({
 });
 
 export const roundHsla = (hsla: HslaColor): HslaColor => ({
-  h: round(hsla.h),
+  // Keep the hue in [0, 360); rounding can otherwise produce 360 (e.g. for
+  // near-360 reds), which breaks round-tripping since parsing normalizes 360 to 0.
+  h: round(hsla.h) % 360,
   s: round(hsla.s),
   l: round(hsla.l),
   a: round(hsla.a, ALPHA_PRECISION),

--- a/src/colorModels/hsv.ts
+++ b/src/colorModels/hsv.ts
@@ -1,6 +1,6 @@
 import { InputObject, RgbaColor, HsvaColor } from "../types";
 import { ALPHA_PRECISION } from "../constants";
-import { clamp, clampHue, isPresent, round } from "../helpers";
+import { clamp, clampHue, isPresent, round, roundHue } from "../helpers";
 
 export const clampHsva = (hsva: HsvaColor): HsvaColor => ({
   h: clampHue(hsva.h),
@@ -10,9 +10,7 @@ export const clampHsva = (hsva: HsvaColor): HsvaColor => ({
 });
 
 export const roundHsva = (hsva: HsvaColor): HsvaColor => ({
-  // Keep the hue in [0, 360); rounding can otherwise produce 360 (e.g. for
-  // near-360 reds), which breaks round-tripping since parsing normalizes 360 to 0.
-  h: round(hsva.h) % 360,
+  h: roundHue(hsva.h),
   s: round(hsva.s),
   v: round(hsva.v),
   a: round(hsva.a, ALPHA_PRECISION),

--- a/src/colorModels/hsv.ts
+++ b/src/colorModels/hsv.ts
@@ -10,7 +10,9 @@ export const clampHsva = (hsva: HsvaColor): HsvaColor => ({
 });
 
 export const roundHsva = (hsva: HsvaColor): HsvaColor => ({
-  h: round(hsva.h),
+  // Keep the hue in [0, 360); rounding can otherwise produce 360 (e.g. for
+  // near-360 reds), which breaks round-tripping since parsing normalizes 360 to 0.
+  h: round(hsva.h) % 360,
   s: round(hsva.s),
   v: round(hsva.v),
   a: round(hsva.a, ALPHA_PRECISION),

--- a/src/colorModels/hwb.ts
+++ b/src/colorModels/hwb.ts
@@ -1,6 +1,6 @@
 import { RgbaColor, HwbaColor, InputObject } from "../types";
 import { ALPHA_PRECISION } from "../constants";
-import { clamp, clampHue, round, isPresent } from "../helpers";
+import { clamp, clampHue, round, roundHue, isPresent } from "../helpers";
 import { hsvaToRgba, rgbaToHsva } from "./hsv";
 
 export const clampHwba = (hwba: HwbaColor): HwbaColor => ({
@@ -11,7 +11,7 @@ export const clampHwba = (hwba: HwbaColor): HwbaColor => ({
 });
 
 export const roundHwba = (hwba: HwbaColor): HwbaColor => ({
-  h: round(hwba.h),
+  h: roundHue(hwba.h),
   w: round(hwba.w),
   b: round(hwba.b),
   a: round(hwba.a, ALPHA_PRECISION),

--- a/src/colorModels/lch.ts
+++ b/src/colorModels/lch.ts
@@ -1,6 +1,6 @@
 import { RgbaColor, InputObject, LchaColor } from "../types";
 import { ALPHA_PRECISION } from "../constants";
-import { clamp, clampHue, isPresent, round } from "../helpers";
+import { clamp, clampHue, isPresent, round, roundHue } from "../helpers";
 import { labaToRgba, rgbaToLaba } from "./lab";
 
 /**
@@ -18,7 +18,7 @@ export const clampLcha = (laba: LchaColor): LchaColor => ({
 export const roundLcha = (laba: LchaColor): LchaColor => ({
   l: round(laba.l, 2),
   c: round(laba.c, 2),
-  h: round(laba.h, 2),
+  h: roundHue(laba.h, 2),
   a: round(laba.a, ALPHA_PRECISION),
 });
 

--- a/src/colord.ts
+++ b/src/colord.ts
@@ -1,5 +1,5 @@
 import { Input, AnyColor, RgbaColor, HslaColor, HsvaColor } from "./types";
-import { round } from "./helpers";
+import { round, roundHue } from "./helpers";
 import { ALPHA_PRECISION } from "./constants";
 import { parse } from "./parse";
 import { rgbaToHex } from "./colorModels/hex";
@@ -172,7 +172,7 @@ export class Colord {
   public hue(value?: number): Colord | number {
     const hsla = rgbaToHsla(this.rgba);
     if (typeof value === "number") return colord({ h: value, s: hsla.s, l: hsla.l, a: hsla.a });
-    return round(hsla.h);
+    return roundHue(hsla.h);
   }
 
   /**

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -28,6 +28,11 @@ export const clamp = (number: number, min = 0, max = 1): number => {
  * Processes and clamps a degree (angle) value properly.
  * Any `NaN` or `Infinity` will be converted to `0`.
  * Examples: -1 => 359, 361 => 1, 360 => 0
+ *
+ * Deliberately not the canonical `((degrees % 360) + 360) % 360`: that form
+ * loses precision for values already in range (`0.4` comes back as
+ * `0.39999999999997726`), and the result reaches the `*ToRgba` conversions
+ * unrounded.
  */
 export const clampHue = (degrees: number): number => {
   degrees = isFinite(degrees) ? degrees % 360 : 0;

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -35,6 +35,16 @@ export const clampHue = (degrees: number): number => {
 };
 
 /**
+ * Rounds a hue and keeps it inside [0, 360).
+ * Rounding alone can produce exactly 360 (a raw hue of 359.6 rounds up), which
+ * every consumer then has to special-case, so the wrap belongs here.
+ * Examples: 359.6 => 0, 12.4 => 12
+ */
+export const roundHue = (degrees: number, digits = 0): number => {
+  return round(degrees, digits) % 360;
+};
+
+/**
  * Converts a hue value to degrees from 0 to 360 inclusive.
  */
 export const parseHue = (value: string, unit = "deg"): number => {

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -29,10 +29,11 @@ export const clamp = (number: number, min = 0, max = 1): number => {
  * Any `NaN` or `Infinity` will be converted to `0`.
  * Examples: -1 => 359, 361 => 1, 360 => 0
  *
- * Deliberately not the canonical `((degrees % 360) + 360) % 360`: that form
- * loses precision for values already in range (`0.4` comes back as
- * `0.39999999999997726`), and the result reaches the `*ToRgba` conversions
- * unrounded.
+ * Deliberately not the canonical `((degrees % 360) + 360) % 360`. That form
+ * perturbs values already in range: `0.4` comes back as `0.39999999999997726`,
+ * and 69% of hues in [0, 360) shift by up to 6e-14 degrees. Far too small to
+ * change any 8-bit output, but the two-step form below is exact for every
+ * in-range value and the same length, so nothing is traded for it.
  */
 export const clampHue = (degrees: number): number => {
   degrees = isFinite(degrees) ? degrees % 360 : 0;

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -27,11 +27,11 @@ export const clamp = (number: number, min = 0, max = 1): number => {
 /**
  * Processes and clamps a degree (angle) value properly.
  * Any `NaN` or `Infinity` will be converted to `0`.
- * Examples: -1 => 359, 361 => 1
+ * Examples: -1 => 359, 361 => 1, 360 => 0
  */
 export const clampHue = (degrees: number): number => {
   degrees = isFinite(degrees) ? degrees % 360 : 0;
-  return degrees > 0 ? degrees : degrees + 360;
+  return degrees < 0 ? degrees + 360 : degrees;
 };
 
 /**

--- a/tests/colord.test.ts
+++ b/tests/colord.test.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 import { colord, random, getFormat, Colord, AnyColor } from "../src/";
 import { fixtures, lime, saturationLevels } from "./fixtures";
-import { clampHue } from "../src/helpers";
+import { clampHue, roundHue } from "../src/helpers";
 
 it("Converts between HEX, RGB, HSL and HSV color models properly", () => {
   for (const fixture of fixtures) {
@@ -60,6 +60,40 @@ it("Clamps a hue into [0, 360)", () => {
   expect(clampHue(NaN)).toBe(0);
   expect(clampHue(-1)).toBe(359);
   expect(clampHue(361)).toBe(1);
+});
+
+it("Rounds a hue into [0, 360)", () => {
+  // The single place the invariant lives, so every model depends on it. The
+  // `digits` argument is used by LCH only.
+  expect(roundHue(359.6)).toBe(0);
+  expect(roundHue(359.4)).toBe(359);
+  expect(roundHue(12.4)).toBe(12);
+  expect(roundHue(0)).toBe(0);
+  expect(roundHue(359.996, 2)).toBe(0);
+  expect(roundHue(359.72, 2)).toBe(359.72);
+});
+
+it("Accepts a hue of 360 on input and reports it as 0", () => {
+  // 360deg is a valid CSS hue and the same angle as 0. Parsing normalizes it,
+  // so nothing downstream has to special-case a full turn.
+  expect(colord({ h: 360, s: 100, l: 50 }).toHsl()).toMatchObject({ h: 0, s: 100, l: 50 });
+  expect(colord({ h: 360, s: 100, v: 100 }).toHsv()).toMatchObject({ h: 0, s: 100, v: 100 });
+  expect(colord("hsl(360, 100%, 50%)").toHslString()).toBe("hsl(0, 100%, 50%)");
+  expect(colord("hsl(360deg 100% 50%)").toHslString()).toBe("hsl(0, 100%, 50%)");
+  expect(colord("hsl(90, 50%, 50%)").hue(360).toHslString()).toBe("hsl(0, 50%, 50%)");
+  // ...and it is the same color as 0, not a different one
+  expect(colord({ h: 360, s: 100, l: 50 }).toHex()).toBe(colord({ h: 0, s: 100, l: 50 }).toHex());
+});
+
+it("Rotates across the 0/360 boundary", () => {
+  // `rotate` reads `hue()`, so it depends on the wrap: for these colors the
+  // getter used to report 360 and now reports 0.
+  const red = colord({ r: 120, g: 0, b: 1 });
+  expect(red.hue()).toBe(0);
+  expect(red.rotate(15).hue()).toBe(15);
+  expect(red.rotate(-15).hue()).toBe(345);
+  expect(colord("hsl(350, 100%, 50%)").rotate(20).hue()).toBe(10);
+  expect(colord("hsl(10, 100%, 50%)").rotate(-20).hue()).toBe(350);
 });
 
 it("Reports the same hue through every accessor", () => {

--- a/tests/colord.test.ts
+++ b/tests/colord.test.ts
@@ -41,6 +41,16 @@ it("Adds alpha number to RGB and HSL strings only if the color has an opacity", 
   expect(colord("hsl(0, 0%, 0%)").alpha(0.5).toHslString()).toBe("hsla(0, 0%, 0%, 0.5)");
 });
 
+it("Keeps the hue within [0, 360) so HSL/HSV round-trips are stable", () => {
+  // rgb(221, 4, 5) has a hue that rounds up to 360, which used to be emitted
+  // verbatim while parsing normalizes it back to 0 — breaking the round-trip.
+  const red = colord({ r: 221, g: 4, b: 5 });
+  expect(red.toHsl().h).toBe(0);
+  expect(red.toHsv().h).toBe(0);
+  expect(colord(red.toHslString()).toHslString()).toBe(red.toHslString());
+  expect(colord(red.toHsv()).toHsv()).toMatchObject(red.toHsv());
+});
+
 it("Parses modern RGB functional notations", () => {
   expect(colord("rgb(0% 50% 100%)").toRgb()).toMatchObject({ r: 0, g: 128, b: 255, a: 1 });
   expect(colord("rgb(10% 20% 30% / 33%)").toRgb()).toMatchObject({ r: 26, g: 51, b: 77, a: 0.33 });

--- a/tests/colord.test.ts
+++ b/tests/colord.test.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 import { colord, random, getFormat, Colord, AnyColor } from "../src/";
 import { fixtures, lime, saturationLevels } from "./fixtures";
+import { clampHue } from "../src/helpers";
 
 it("Converts between HEX, RGB, HSL and HSV color models properly", () => {
   for (const fixture of fixtures) {
@@ -49,6 +50,16 @@ it("Keeps the hue within [0, 360) so HSL/HSV round-trips are stable", () => {
   expect(red.toHsv().h).toBe(0);
   expect(colord(red.toHslString()).toHslString()).toBe(red.toHslString());
   expect(colord(red.toHsv()).toHsv()).toMatchObject(red.toHsv());
+});
+
+it("Clamps a hue into [0, 360)", () => {
+  // The upper bound is exclusive, and non-finite input falls back to 0 — both
+  // are relied upon by every model that carries a hue.
+  expect(clampHue(360)).toBe(0);
+  expect(clampHue(0)).toBe(0);
+  expect(clampHue(NaN)).toBe(0);
+  expect(clampHue(-1)).toBe(359);
+  expect(clampHue(361)).toBe(1);
 });
 
 it("Reports the same hue through every accessor", () => {

--- a/tests/colord.test.ts
+++ b/tests/colord.test.ts
@@ -51,6 +51,21 @@ it("Keeps the hue within [0, 360) so HSL/HSV round-trips are stable", () => {
   expect(colord(red.toHsv()).toHsv()).toMatchObject(red.toHsv());
 });
 
+it("Reports the same hue through every accessor", () => {
+  // Each of these rounds the hue separately, so they can drift apart if any of
+  // them forgets to wrap 360 back to 0.
+  for (const rgb of [
+    { r: 221, g: 4, b: 5 },
+    { r: 120, g: 0, b: 1 },
+    { r: 121, g: 1, b: 2 },
+  ]) {
+    const color = colord(rgb);
+    expect(color.hue()).toBe(color.toHsl().h);
+    expect(color.hue()).toBe(color.toHsv().h);
+    expect(color.hue()).toBe(0);
+  }
+});
+
 it("Parses modern RGB functional notations", () => {
   expect(colord("rgb(0% 50% 100%)").toRgb()).toMatchObject({ r: 0, g: 128, b: 255, a: 1 });
   expect(colord("rgb(10% 20% 30% / 33%)").toRgb()).toMatchObject({ r: 26, g: 51, b: 77, a: 0.33 });

--- a/tests/plugins.test.ts
+++ b/tests/plugins.test.ts
@@ -138,9 +138,14 @@ describe("hwb", () => {
     expect(colord("#665533").toHwb()).toMatchObject({ h: 40, w: 20, b: 60, a: 1 });
     expect(colord("#feacfa").toHwb()).toMatchObject({ h: 303, w: 67, b: 0, a: 1 });
     expect(colord("#ffffff").toHwb()).toMatchObject({ h: 0, w: 100, b: 0, a: 1 });
-    // A hue that rounds up to 360 must wrap to 0 like everywhere else
-    expect(colord({ r: 120, g: 0, b: 1 }).toHwb()).toMatchObject({ h: 0 });
-    expect(colord({ r: 120, g: 0, b: 1 }).toHwbString()).toBe("hwb(0 0% 53%)");
+    // A hue that rounds up to 360 must wrap to 0 like everywhere else, and must
+    // agree with the other models — HWB reads the very same hue as HSL.
+    const red = colord({ r: 120, g: 0, b: 1 });
+    expect(red.toHwb()).toMatchObject({ h: 0 });
+    expect(red.toHwb().h).toBe(red.toHsl().h);
+    expect(red.toHwbString()).toBe("hwb(0 0% 53%)");
+    expect(colord({ h: 360, w: 0, b: 0 }).toHwb()).toMatchObject({ h: 0 });
+    expect(colord("hwb(360 0% 0%)").toHwbString()).toBe("hwb(0 0% 0%)");
   });
 
   it("Parses HWB color string", () => {
@@ -266,6 +271,9 @@ describe("lch", () => {
   it("Keeps the LCH hue within [0, 360)", () => {
     // The Lab-derived hue can round up to exactly 360; it must wrap to 0.
     expect(colord({ r: 48, g: 7, b: 24 }).toLch().h).toBe(0);
+    expect(colord({ r: 48, g: 7, b: 24 }).toLchString()).toBe("lch(7.82% 22.2 0)");
+    expect(colord({ l: 50, c: 50, h: 360 }).toLch()).toMatchObject({ h: 0 });
+    expect(colord("lch(50% 50 360)").toLchString()).toBe("lch(50% 50 0)");
   });
 
   it("Converts a color to CIE LCH string (CSS functional notation)", () => {

--- a/tests/plugins.test.ts
+++ b/tests/plugins.test.ts
@@ -138,6 +138,9 @@ describe("hwb", () => {
     expect(colord("#665533").toHwb()).toMatchObject({ h: 40, w: 20, b: 60, a: 1 });
     expect(colord("#feacfa").toHwb()).toMatchObject({ h: 303, w: 67, b: 0, a: 1 });
     expect(colord("#ffffff").toHwb()).toMatchObject({ h: 0, w: 100, b: 0, a: 1 });
+    // A hue that rounds up to 360 must wrap to 0 like everywhere else
+    expect(colord({ r: 120, g: 0, b: 1 }).toHwb()).toMatchObject({ h: 0 });
+    expect(colord({ r: 120, g: 0, b: 1 }).toHwbString()).toBe("hwb(0 0% 53%)");
   });
 
   it("Parses HWB color string", () => {
@@ -258,6 +261,11 @@ describe("lch", () => {
     expect(colord("#9d9318").toLch()).toMatchObject({ l: 60.31, c: 59.2, h: 95.46, a: 1 });
     expect(colord("#68a639").toLch()).toMatchObject({ l: 62.22, c: 59.15, h: 126.15, a: 1 });
     expect(colord("#62acef80").toLch()).toMatchObject({ l: 67.67, c: 42.18, h: 257.79, a: 0.5 });
+  });
+
+  it("Keeps the LCH hue within [0, 360)", () => {
+    // The Lab-derived hue can round up to exactly 360; it must wrap to 0.
+    expect(colord({ r: 48, g: 7, b: 24 }).toLch().h).toBe(0);
   });
 
   it("Converts a color to CIE LCH string (CSS functional notation)", () => {


### PR DESCRIPTION
`toHsl()` / `toHsv()` can return a hue of `360`, which doesn't round-trip:

```js
const c = colord({ r: 221, g: 4, b: 5 });
c.toHslString();                               // "hsl(360, 96%, 44%)"
colord(c.toHslString()).toHslString();         // "hsl(0, 96%, 44%)"  ← differs
c.toHsl().h;                                    // 360
```

The raw hue for some reds is just under 360 and rounds up to `360`, but parsing normalizes `360` back to `0`, so output ≠ re-parsed output. Every other place keeps the hue in `[0, 360)`.

The fix takes the rounded hue `% 360`, so a rounded-up `360` becomes `0` and all other hues are unchanged. I came across it fuzzing `colord(c.toHslString()).toHslString() === c.toHslString()` over random colors (56 reds hit it for both HSL and HSV). Added a regression test; lint, types and the full suite pass.
