### PR TITLE
fix: keep full alpha precision when parsing hex colors

### DIFF
--- a/src/colorModels/hex.ts
+++ b/src/colorModels/hex.ts
@@ -1,5 +1,6 @@
 import { RgbaColor } from "../types";
 import { round } from "../helpers";
+import { ALPHA_PRECISION } from "../constants";
 import { roundRgba } from "./rgb";
 
 const hexMatcher = /^#([0-9a-f]{3,8})$/i;
@@ -17,7 +18,7 @@ export const parseHex = (hex: string): RgbaColor | null => {
       r: parseInt(hex[0] + hex[0], 16),
       g: parseInt(hex[1] + hex[1], 16),
       b: parseInt(hex[2] + hex[2], 16),
-      a: hex.length === 4 ? round(parseInt(hex[3] + hex[3], 16) / 255, 2) : 1,
+      a: hex.length === 4 ? round(parseInt(hex[3] + hex[3], 16) / 255, ALPHA_PRECISION) : 1,
     };
   }
 
@@ -26,7 +27,7 @@ export const parseHex = (hex: string): RgbaColor | null => {
       r: parseInt(hex.substr(0, 2), 16),
       g: parseInt(hex.substr(2, 2), 16),
       b: parseInt(hex.substr(4, 2), 16),
-      a: hex.length === 8 ? round(parseInt(hex.substr(6, 2), 16) / 255, 2) : 1,
+      a: hex.length === 8 ? round(parseInt(hex.substr(6, 2), 16) / 255, ALPHA_PRECISION) : 1,
     };
   }
 

--- a/tests/colord.test.ts
+++ b/tests/colord.test.ts
@@ -56,12 +56,20 @@ it("Parses modern HSL functional notations", () => {
 
 it("Supports HEX4 and HEX8 color models", () => {
   expect(colord("#ffffffff").toRgb()).toMatchObject({ r: 255, g: 255, b: 255, a: 1 });
-  expect(colord("#80808080").toRgb()).toMatchObject({ r: 128, g: 128, b: 128, a: 0.5 });
+  expect(colord("#80808080").toRgb()).toMatchObject({ r: 128, g: 128, b: 128, a: 0.502 });
   expect(colord("#AAAF").toRgb()).toMatchObject({ r: 170, g: 170, b: 170, a: 1 });
   expect(colord("#5550").toRgb()).toMatchObject({ r: 85, g: 85, b: 85, a: 0 });
   expect(colord({ r: 255, g: 255, b: 255, a: 1 }).toHex()).toBe("#ffffff");
   expect(colord({ r: 170, g: 170, b: 170, a: 0.5 }).toHex()).toBe("#aaaaaa80");
   expect(colord({ r: 128, g: 128, b: 128, a: 0 }).toHex()).toBe("#80808000");
+});
+
+it("Round-trips a HEX8 alpha channel without drifting", () => {
+  // The alpha byte of a HEX8 string is 8-bit; parsing must keep enough
+  // precision (ALPHA_PRECISION) to re-encode the very same byte.
+  ["#476d5e55", "#80808080", "#0a141e7f", "#ffffff01", "#000000fe"].forEach((hex) => {
+    expect(colord(hex).toHex()).toBe(hex);
+  });
 });
 
 it("Ignores a case and extra whitespace", () => {


### PR DESCRIPTION
## The problem

A HEX8 color does not survive a round-trip through colord:

```js
colord("#476d5e55").toHex(); // "#476d5e54"  ← the alpha byte drifted 0x55 → 0x54
```

This affects **155 of the 255** fractional alpha bytes.

## Root cause

`parseHex` rounds the parsed alpha to **2** decimals:

```js
a: hex.length === 8 ? round(parseInt(hex.substr(6, 2), 16) / 255, 2) : 1,
```

…but the rest of the library uses `ALPHA_PRECISION`, which is `3`, and its own comment explains exactly this failure mode:

```js
// constants.ts
/**
 * We used to work with 2 digits after the decimal point, but it wasn't accurate enough,
 * so the library produced colors that were perceived differently.
 */
export const ALPHA_PRECISION = 3;
```

`roundRgba` (used by `rgbaToHex` and every output method) already rounds alpha to `ALPHA_PRECISION`, and object/`rgb()` inputs keep full precision via `clampRgba`. Only `parseHex` was left on the old hard-coded `2`, so a hex alpha of `0x55` (85 / 255 = 0.3333…) is stored as `0.33`, and `round(0.33 * 255) = 84 = 0x54` on the way back out.

2 decimals simply cannot represent every 8-bit alpha byte; 3 can (verified across all 0–254 fractional bytes: 2 digits drifts 155 of them, 3 digits drifts none).

## Fix

Use `ALPHA_PRECISION` in `parseHex`, matching the rest of the library. Every HEX8 alpha byte now round-trips exactly, and hex parsing is consistent with `rgb()`/object inputs.

## Test plan

- New test: `colord(hex).toHex() === hex` for a spread of HEX8 alpha bytes (fails on `main`, passes here).
- One existing assertion updated: `colord("#80808080").toRgb().a` is `0.502` rather than `0.5` — `128 / 255 = 0.50196…`, i.e. the value the documented 3-digit precision produces (the old `0.5` was the 2-digit approximation this change moves away from).
- Full suite green (`jest`).
