### PR TITLE
fix: reject malformed color strings in linear time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 2.9.4
+
+- Fix: Reject malformed color strings in linear time ❤️ [@GAP-dev](https://github.com/GAP-dev)
+
 ### 2.9.3
 
 - Fix types export for TypeScript 4.7 ❤️ [@pkishorez](https://github.com/pkishorez)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "colord",
-  "version": "2.9.3",
+  "version": "2.9.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "colord",
-      "version": "2.9.3",
+      "version": "2.9.4",
       "license": "MIT",
       "devDependencies": {
         "@size-limit/preset-small-lib": "^11.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "colord",
-  "version": "2.9.3",
+  "version": "2.9.4",
   "description": "👑 A tiny yet powerful tool for high-performance color manipulations and conversions",
   "keywords": [
     "color",

--- a/src/colorModels/cmykString.ts
+++ b/src/colorModels/cmykString.ts
@@ -1,7 +1,7 @@
 import { RgbaColor } from "../types";
 import { clampCmyka, cmykaToRgba, rgbaToCmyka, roundCmyka } from "./cmyk";
 
-const cmykMatcher = /^device-cmyk\(\s*([+-]?\d*\.?\d+)(%)?\s+([+-]?\d*\.?\d+)(%)?\s+([+-]?\d*\.?\d+)(%)?\s+([+-]?\d*\.?\d+)(%)?\s*(?:\/\s*([+-]?\d*\.?\d+)(%)?\s*)?\)$/i;
+const cmykMatcher = /^device-cmyk\(\s*([+-]?(?:\d*\.\d+|\d+))(%)?\s+([+-]?(?:\d*\.\d+|\d+))(%)?\s+([+-]?(?:\d*\.\d+|\d+))(%)?\s+([+-]?(?:\d*\.\d+|\d+))(%)?\s*(?:\/\s*([+-]?(?:\d*\.\d+|\d+))(%)?\s*)?\)$/i;
 
 /**
  * Parses a valid CMYK CSS color function/string

--- a/src/colorModels/hslString.ts
+++ b/src/colorModels/hslString.ts
@@ -4,11 +4,11 @@ import { clampHsla, rgbaToHsla, hslaToRgba, roundHsla } from "./hsl";
 
 // Functional syntax
 // hsl( <hue>, <percentage>, <percentage>, <alpha-value>? )
-const commaHslaMatcher = /^hsla?\(\s*([+-]?\d*\.?\d+)(deg|rad|grad|turn)?\s*,\s*([+-]?\d*\.?\d+)%\s*,\s*([+-]?\d*\.?\d+)%\s*(?:,\s*([+-]?\d*\.?\d+)(%)?\s*)?\)$/i;
+const commaHslaMatcher = /^hsla?\(\s*([+-]?(?:\d*\.\d+|\d+))(deg|rad|grad|turn)?\s*,\s*([+-]?(?:\d*\.\d+|\d+))%\s*,\s*([+-]?(?:\d*\.\d+|\d+))%\s*(?:,\s*([+-]?(?:\d*\.\d+|\d+))(%)?\s*)?\)$/i;
 
 // Whitespace syntax
 // hsl( <hue> <percentage> <percentage> [ / <alpha-value> ]? )
-const spaceHslaMatcher = /^hsla?\(\s*([+-]?\d*\.?\d+)(deg|rad|grad|turn)?\s+([+-]?\d*\.?\d+)%\s+([+-]?\d*\.?\d+)%\s*(?:\/\s*([+-]?\d*\.?\d+)(%)?\s*)?\)$/i;
+const spaceHslaMatcher = /^hsla?\(\s*([+-]?(?:\d*\.\d+|\d+))(deg|rad|grad|turn)?\s+([+-]?(?:\d*\.\d+|\d+))%\s+([+-]?(?:\d*\.\d+|\d+))%\s*(?:\/\s*([+-]?(?:\d*\.\d+|\d+))(%)?\s*)?\)$/i;
 
 /**
  * Parses a valid HSL[A] CSS color function/string

--- a/src/colorModels/hwbString.ts
+++ b/src/colorModels/hwbString.ts
@@ -4,7 +4,7 @@ import { clampHwba, rgbaToHwba, hwbaToRgba, roundHwba } from "./hwb";
 
 // The only valid HWB syntax
 // hwb( <hue> <percentage> <percentage> [ / <alpha-value> ]? )
-const hwbaMatcher = /^hwb\(\s*([+-]?\d*\.?\d+)(deg|rad|grad|turn)?\s+([+-]?\d*\.?\d+)%\s+([+-]?\d*\.?\d+)%\s*(?:\/\s*([+-]?\d*\.?\d+)(%)?\s*)?\)$/i;
+const hwbaMatcher = /^hwb\(\s*([+-]?(?:\d*\.\d+|\d+))(deg|rad|grad|turn)?\s+([+-]?(?:\d*\.\d+|\d+))%\s+([+-]?(?:\d*\.\d+|\d+))%\s*(?:\/\s*([+-]?(?:\d*\.\d+|\d+))(%)?\s*)?\)$/i;
 
 /**
  * Parses a valid HWB[A] CSS color function/string

--- a/src/colorModels/lchString.ts
+++ b/src/colorModels/lchString.ts
@@ -4,7 +4,7 @@ import { clampLcha, rgbaToLcha, lchaToRgba, roundLcha } from "./lch";
 
 // The only valid LCH syntax
 // lch() = lch( <percentage> <number> <hue> [ / <alpha-value> ]? )
-const lchaMatcher = /^lch\(\s*([+-]?\d*\.?\d+)%\s+([+-]?\d*\.?\d+)\s+([+-]?\d*\.?\d+)(deg|rad|grad|turn)?\s*(?:\/\s*([+-]?\d*\.?\d+)(%)?\s*)?\)$/i;
+const lchaMatcher = /^lch\(\s*([+-]?(?:\d*\.\d+|\d+))%\s+([+-]?(?:\d*\.\d+|\d+))\s+([+-]?(?:\d*\.\d+|\d+))(deg|rad|grad|turn)?\s*(?:\/\s*([+-]?(?:\d*\.\d+|\d+))(%)?\s*)?\)$/i;
 
 /**
  * Parses a valid LCH CSS color function/string

--- a/src/colorModels/rgbString.ts
+++ b/src/colorModels/rgbString.ts
@@ -4,12 +4,12 @@ import { roundRgba, clampRgba } from "./rgb";
 // Functional syntax
 // rgb( <percentage>#{3} , <alpha-value>? )
 // rgb( <number>#{3} , <alpha-value>? )
-const commaRgbaMatcher = /^rgba?\(\s*([+-]?\d*\.?\d+)(%)?\s*,\s*([+-]?\d*\.?\d+)(%)?\s*,\s*([+-]?\d*\.?\d+)(%)?\s*(?:,\s*([+-]?\d*\.?\d+)(%)?\s*)?\)$/i;
+const commaRgbaMatcher = /^rgba?\(\s*([+-]?(?:\d*\.\d+|\d+))(%)?\s*,\s*([+-]?(?:\d*\.\d+|\d+))(%)?\s*,\s*([+-]?(?:\d*\.\d+|\d+))(%)?\s*(?:,\s*([+-]?(?:\d*\.\d+|\d+))(%)?\s*)?\)$/i;
 
 // Whitespace syntax
 // rgb( <percentage>{3} [ / <alpha-value> ]? )
 // rgb( <number>{3} [ / <alpha-value> ]? )
-const spaceRgbaMatcher = /^rgba?\(\s*([+-]?\d*\.?\d+)(%)?\s+([+-]?\d*\.?\d+)(%)?\s+([+-]?\d*\.?\d+)(%)?\s*(?:\/\s*([+-]?\d*\.?\d+)(%)?\s*)?\)$/i;
+const spaceRgbaMatcher = /^rgba?\(\s*([+-]?(?:\d*\.\d+|\d+))(%)?\s+([+-]?(?:\d*\.\d+|\d+))(%)?\s+([+-]?(?:\d*\.\d+|\d+))(%)?\s*(?:\/\s*([+-]?(?:\d*\.\d+|\d+))(%)?\s*)?\)$/i;
 
 /**
  * Parses a valid RGB[A] CSS color function/string

--- a/tests/colord.test.ts
+++ b/tests/colord.test.ts
@@ -100,6 +100,18 @@ it("Ignores invalid color formats", () => {
   // wrong content
   expect(colord("rgb(10, 10, 10, var(--alpha))").isValid()).toBe(false);
   expect(colord("hsl(var(--h) 10% 10%)").isValid()).toBe(false);
+  // trailing decimal point
+  expect(colord("rgb(1., 2, 3)").isValid()).toBe(false);
+  expect(colord("rgb(., 2, 3)").isValid()).toBe(false);
+  expect(colord("hsl(1., 20%, 30%)").isValid()).toBe(false);
+  expect(colord("rgba(1, 2, 3, 4.)").isValid()).toBe(false);
+});
+
+it("Parses numbers with an omitted integer part", () => {
+  expect(colord("rgb(.5, .5, .5)").isValid()).toBe(true);
+  expect(colord("rgb(.5% .5% .5%)").isValid()).toBe(true);
+  expect(colord("hsl(.5, .5%, .5%)").isValid()).toBe(true);
+  expect(colord("hsl(.5deg .5% .5% / .5)").isValid()).toBe(true);
 });
 
 it("Clamps input numbers", () => {

--- a/tests/parse-complexity.test.ts
+++ b/tests/parse-complexity.test.ts
@@ -1,0 +1,50 @@
+import { colord, extend } from "../src/";
+import cmykPlugin from "../src/plugins/cmyk";
+import hwbPlugin from "../src/plugins/hwb";
+import lchPlugin from "../src/plugins/lch";
+
+extend([cmykPlugin, hwbPlugin, lchPlugin]);
+
+/**
+ * Every CSS function matcher spells a number as `(?:\d*\.\d+|\d+)` instead of the
+ * shorter `\d*\.?\d+`. The shorter form lets two quantifiers match the same digits,
+ * so a long malformed color can be divided between them in O(n²) ways, and a
+ * rejection retries every division. Parsing is synchronous and uninterruptible,
+ * so that time is taken from everything else sharing the thread.
+ *
+ * The two forms accept exactly the same strings, which means no assertion about
+ * parsing results can tell them apart — only running time can. The budget below is
+ * deliberately loose: these inputs need well under a millisecond with an
+ * unambiguous number and several seconds without one, so a slow or noisy machine
+ * cannot turn this into a flaky test.
+ */
+const LENGTH = 64000;
+const BUDGET_MS = 500;
+
+// A number long enough to be expensive, followed by a character that cannot appear
+// in any color function, forcing the matcher to reject the input.
+const digits = "1".repeat(LENGTH);
+
+const parseDuration = (input: string): number => {
+  const start = Date.now();
+  expect(colord(input).isValid()).toBe(false);
+  return Date.now() - start;
+};
+
+describe("Rejects oversized malformed colors in linear time", () => {
+  it.each([
+    ["rgb", `rgb(${digits}!`],
+    ["rgb, alpha position", `rgba(1, 2, 3, ${digits}!`],
+    ["hsl", `hsl(${digits}!`],
+    ["hsl, alpha position", `hsl(1deg 2% 3% / ${digits}!`],
+    ["hwb", `hwb(${digits}!`],
+    ["lch", `lch(${digits}!`],
+    ["device-cmyk", `device-cmyk(${digits}!`],
+  ])(
+    "%s",
+    (_name, input) => {
+      expect(parseDuration(input)).toBeLessThan(BUDGET_MS);
+    },
+    30000
+  );
+});


### PR DESCRIPTION
## What

Every CSS function matcher described a number as `([+-]?\d*\.?\d+)`. In that form `\d*` and `\d+` compete for the same digits, so a run of *n* digits can be divided between them in O(n²) ways — and each division is a legitimate match, so rejecting an input retries all of them before giving up.

The result is that *rejecting* a long malformed color costs quadratic time, and since parsing is synchronous and uninterruptible, that time comes out of everything else sharing the thread:

| input | before | after |
|---|---|---|
| 16 KB | 224 ms | 0.07 ms |
| 64 KB | 4,442 ms | 0.21 ms |
| 128 KB | 18,477 ms | 0.43 ms |
| 1 MB | — | 5.3 ms |

Any service that hands a request body, JSON field, or uploaded stylesheet to `colord()` inherits that, and nothing bounds input length before the matchers run.

## The change

Spell the same number as `([+-]?(?:\d*\.\d+|\d+))`. `\d*\.?\d+` accepts exactly two shapes — a plain digit run, or digits-dot-digits with the leading digits optional — so writing those two branches explicitly leaves exactly one way to match any given number. Nothing can be re-divided, and rejection becomes linear. 29 occurrences across 6 files.

No limits, caps, or guard clauses were added, and the accepted syntax is unchanged.

## Verifying the syntax didn't change

The two forms should describe an identical language, so I checked it rather than assumed it: **976,028 comparisons** across all 7 matchers over a generated corpus (every combination of number shape, unit, separator, and whitespace, plus targeted `lch`/`device-cmyk` generation), comparing both match/no-match **and every capture group value**. Zero differences. Capture numbering is untouched since `(?:…)` is non-capturing.

## Tests

Behaviour-preserving is the awkward part: **no assertion about parsing results can distinguish the two forms**, so nothing in the existing suite would notice a revert to the ambiguous version. I confirmed that by mutation testing — reverting the atom passed all 77 existing tests.

`tests/parse-complexity.test.ts` covers it by time instead, over all seven matchers including the alpha positions. The budget is 500 ms against a real cost of ~0.2 ms and a regressed cost of ~4,400 ms, so it sits three orders of magnitude clear of the passing case and ~9× under the failing one — it cannot flake on a slow runner, and it fails loudly if the atom is ever "simplified" back.

Mutation results, existing suite vs. this branch:

| mutation of the number atom | before | now |
|---|---|---|
| integer only, `\d+` | 16 failed | 16 failed |
| decimal only, `\d*\.\d+` | 30 failed | 30 failed |
| sign required / sign dropped | 30 / 5 failed | 30 / 5 failed |
| branch order swapped | passed | passed — genuinely equivalent, not a defect |
| **trailing dot allowed**, `\d*\.\d*` | **passed** | **1 failed** |
| **revert to `\d*\.?\d+`** | **passed** | **7 failed** |

The trailing-dot case is new mutation surface that the branch structure itself introduced, so `colord.test.ts` now pins `rgb(1., 2, 3)` and friends as invalid, plus a positive test for the omitted integer part (`rgb(.5, .5, .5)`) that was previously only covered incidentally via alpha values.

85 tests pass. `eslint` and `tsc --noEmit` clean.

## Cost

Normal parsing is not slower — rejection is meaningfully faster, since it no longer explores dead divisions:

| | before | after |
|---|---|---|
| valid colors | 5,032,924 parses/sec | 5,194,580 parses/sec |
| invalid colors | 4,444,979 parses/sec | 6,170,299 parses/sec |
| mixed | 4,757,657 parses/sec | 5,401,026 parses/sec |

Bundle size grows by a few bytes per affected entry point, all still within their limits (`size-limit` exits 0):

| entry | before | after | limit |
|---|---|---|---|
| `index.mjs` | 1.70 kB | 1.71 kB | 2 kB |
| `plugins/cmyk.mjs` | 609 B | 625 B | 1 kB |
| `plugins/hwb.mjs` | 814 B | 821 B | 1 kB |
| `plugins/lch.mjs` | 1.29 kB | 1.30 kB | 1.5 kB |
