### PR TITLE
chore: fix release packaging for npm 10

### DIFF
--- a/package.json
+++ b/package.json
@@ -101,6 +101,9 @@
   "files": [
     "*.{js,mjs,ts,map}",
     "plugins/*.{js,mjs,ts,map}",
+    "**/*.d.ts",
+    "README.md",
+    "CHANGELOG.md",
     "LICENSE.md"
   ],
   "types": "index.d.ts",
@@ -111,7 +114,7 @@
     "test": "jest tests --coverage",
     "benchmark": "tsc --outDir bench --skipLibCheck --esModuleInterop ./tests/benchmark.ts && node ./bench/tests/benchmark.js && rm -rf ./bench",
     "build": "rm -rf ./dist/* && rollup --config",
-    "release": "npm run build && cp *.json dist && cp *.md dist && npm publish dist",
+    "release": "npm run build && cp *.json dist && cp *.md dist && npm publish ./dist",
     "check-release": "npm run release -- --dry-run"
   },
   "devDependencies": {


### PR DESCRIPTION
Found while dry-running a release of 2.9.4: **`npm run release` would not have published colord at all.**

## `npm publish dist` → `npm publish ./dist`

Since npm 7, a bare argument to `npm publish` is resolved as a *registry spec*, not a folder. So the script was reaching for the unrelated package literally named `dist` on npm. The dry run makes it unambiguous:

```
$ npm run check-release        # before
npm notice name: dist
npm notice version: 0.1.2
+ dist@0.1.2                   # ← someone else's package

$ npm run check-release        # after
npm notice name: colord
npm notice version: 2.9.4
+ colord@2.9.4
```

It worked in npm 6, which is what 2.9.3 was released with. Running it as-is today would have attempted to publish `dist` and failed on permissions, leaving 2.9.4 unpublished.

## `files`: restore `CHANGELOG.md`

Old npm added `CHANGELOG.md` to the tarball automatically; npm 10 no longer does. 2.9.3 shipped it, 2.9.4 would silently have dropped it. `README.md`, `CHANGELOG.md` and `LICENSE.md` are now listed explicitly rather than relying on npm's implicit set.

## `files`: ship internal `.d.ts`

`rollup-plugin-typescript2` emits declarations for every internal module into `dist/` — `colorModels/`, `get/`, `manipulate/`, 23 files — and `files` excluded all of them.

That works today, and has worked since 2.9.3, because the declaration graph happens to be closed over the package root: all public types live in `types.d.ts`, and internal modules are only used at value level, so no shipped `.d.ts` references them (verified: 18 declarations, 27 relative references, 0 dangling). But it holds only as long as nobody ever puts an internal type in an exported signature — and nothing would catch that: `tsc --noEmit` checks `src`, not the tarball, and tests import from `src` too. The first such change would ship a package whose types don't resolve.

Shipping them removes the failure mode for ~10 kB uncompressed (tarball 31.6 → 35.5 kB compressed; **no effect on bundle size** — `size-limit` measures `dist/index.mjs`).

## Verification

Packed the tarball and type-checked a consumer that imports the whole public surface — `colord`, `Colord`, `extend`, `getFormat`, `random`, all 15 exported types, `Plugin`, and all 10 plugin subpaths — with `strict` on and `skipLibCheck` **off**, TypeScript 5.9.3:

| | node | node16 | nodenext | bundler |
|---|---|---|---|---|
| published 2.9.3 | OK | OK | OK | OK |
| this branch | OK | OK | OK | OK |

Runtime behaviour against the published 2.9.3 tarball: 39 inputs × 45 methods = **1755 comparisons, 0 differences**, in both ESM and CJS.

Tarball composition vs published 2.9.3: **nothing lost**, 23 additions, all `.d.ts`.

85 tests pass, `size-limit` exits 0.

## One consequence worth knowing

With the internal declarations shipped, a consumer on legacy `moduleResolution: node` can now type-import them (`colord/colorModels/rgb`), because node10 resolution ignores the `exports` map. `node16`, `nodenext` and `bundler` all correctly reject it, and there is no JS counterpart in the package — the runtime bundle is flattened — so a value import would type-check and then fail at runtime. Nothing that previously worked changes; this only adds a way to hold it wrong on old resolution settings.
