### PR TITLE
docs: replace dead bundlephobia badges in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
 ## Features
 
 - 📦 **Small**: Just **1.7 KB** brotlied ([4x+ lighter](#benchmarks) than **color**)
-- 🚀 **Fast**: [3x+ faster](#benchmarks) than **color**
+- 🚀 **Fast**: [4x+ faster](#benchmarks) than **color**
 - 😍 **Simple**: Chainable API and familiar patterns
 - 💪 **Immutable**: No need to worry about data mutations
 - 🛡 **Bulletproof**: Written in strict TypeScript and has 100% test coverage

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@
 | ac-colors                     | 660,722                       | 10.4 kB               | 3.45 kB              | [![](https://badgen.net/npm/types/ac-colors?color=red&label=)](https://npmjs.com/package/ac-colors)      |
 | chroma-js                     | 962,967                       | 42.9 kB               | 17.6 kB              | [![](https://badgen.net/npm/types/chroma-js?color=e6591d&label=)](https://npmjs.com/package/chroma-js)   |
 
-The performance results were generated on an MBP 2019, 2,6 GHz Intel Core i7 by running `npm run benchmark` in the library folder. See [tests/benchmark.ts](https://github.com/omgovich/colord/blob/master/tests/benchmark.ts). Bundle sizes were measured with [bundlejs](https://bundlejs.com/) for colord@2.9.3, color@5.0.3, tinycolor2@1.6.0, ac-colors@1.4.3 and chroma-js@3.2.0, importing each library's full entry point. The 1.7 KB above is smaller because it is the tree-shaken `{ colord }` import alone, as measured by `npm run size`.
+The performance results were generated on an MBP 2019, 2,6 GHz Intel Core i7 by running `npm run benchmark` in the library folder. See [tests/benchmark.ts](https://github.com/omgovich/colord/blob/master/tests/benchmark.ts). Bundle sizes were measured with [bundlejs](https://bundlejs.com/) for colord@2.9.3, color@5.0.3, tinycolor2@1.6.0, ac-colors@1.4.3 and chroma-js@3.2.0, importing each library's full entry point, so they sit above the tree-shaken `{ colord }` figure quoted under Features, which comes from `npm run size`.
 
 <div><img src="assets/divider.png" width="838" alt="---" /></div>
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
 
 ## Features
 
-- 📦 **Small**: Just **1.7 KB** gzipped ([3x+ lighter](#benchmarks) than **color** and **tinycolor2**)
+- 📦 **Small**: Just **1.7 KB** brotlied ([2.7x+ lighter](#benchmarks) than **color** and **tinycolor2**)
 - 🚀 **Fast**: [3x+ faster](#benchmarks) than **color** and **tinycolor2**
 - 😍 **Simple**: Chainable API and familiar patterns
 - 💪 **Immutable**: No need to worry about data mutations
@@ -40,15 +40,15 @@
 
 ## Benchmarks
 
-| Library                       | <nobr>Operations/sec</nobr>   | Size<br /> (minified) | Size<br /> (gzipped) | Type declarations                                                                                        |
-| ----------------------------- | ----------------------------- | --------------------- | -------------------- | -------------------------------------------------------------------------------------------------------- |
-| <nobr><b>colord 👑</b></nobr> | <nobr><b>3,524,989</b></nobr> | <b>5.88 kB</b>        | <b>2.02 kB</b>       | [![](https://badgen.net/npm/types/colord?color=6ead0a&label=)](https://npmjs.com/package/colord)         |
-| color                         | 744,263                       | 24 kB                 | 8.59 kB              | [![](https://badgen.net/npm/types/color?color=6ead0a&label=)](https://npmjs.com/package/color)           |
-| tinycolor2                    | 971,312                       | 15.3 kB               | 5.34 kB              | [![](https://badgen.net/npm/types/tinycolor2?color=e6591d&label=)](https://npmjs.com/package/tinycolor2) |
-| ac-colors                     | 660,722                       | 10.4 kB               | 3.45 kB              | [![](https://badgen.net/npm/types/ac-colors?color=red&label=)](https://npmjs.com/package/ac-colors)      |
-| chroma-js                     | 962,967                       | 42.9 kB               | 17.6 kB              | [![](https://badgen.net/npm/types/chroma-js?color=e6591d&label=)](https://npmjs.com/package/chroma-js)   |
+| Library                       | <nobr>Operations/sec</nobr>   | Size<br /> (minified) | Size<br /> (brotlied) | Type declarations                                                                                        |
+| ----------------------------- | ----------------------------- | --------------------- | --------------------- | -------------------------------------------------------------------------------------------------------- |
+| <nobr><b>colord 👑</b></nobr> | <nobr><b>3,524,989</b></nobr> | <b>5.71 kB</b>        | <b>1.71 kB</b>        | [![](https://badgen.net/npm/types/colord?color=6ead0a&label=)](https://npmjs.com/package/colord)         |
+| color                         | 744,263                       | 24 kB                 | 7.52 kB               | [![](https://badgen.net/npm/types/color?color=6ead0a&label=)](https://npmjs.com/package/color)           |
+| tinycolor2                    | 971,312                       | 15.23 kB              | 4.67 kB               | [![](https://badgen.net/npm/types/tinycolor2?color=e6591d&label=)](https://npmjs.com/package/tinycolor2) |
+| ac-colors                     | 660,722                       | 10.18 kB              | 2.96 kB               | [![](https://badgen.net/npm/types/ac-colors?color=red&label=)](https://npmjs.com/package/ac-colors)      |
+| chroma-js                     | 962,967                       | 42.47 kB              | 14.89 kB              | [![](https://badgen.net/npm/types/chroma-js?color=e6591d&label=)](https://npmjs.com/package/chroma-js)   |
 
-The performance results were generated on an MBP 2019, 2,6 GHz Intel Core i7 by running `npm run benchmark` in the library folder. See [tests/benchmark.ts](https://github.com/omgovich/colord/blob/master/tests/benchmark.ts). Bundle sizes were measured with [bundlejs](https://bundlejs.com/) for colord@2.9.3, color@5.0.3, tinycolor2@1.6.0, ac-colors@1.4.3 and chroma-js@3.2.0, importing each library's full entry point, so they sit above the tree-shaken `{ colord }` figure quoted under Features, which comes from `npm run size`.
+The performance results were generated on an MBP 2019, 2,6 GHz Intel Core i7 by running `npm run benchmark` in the library folder. See [tests/benchmark.ts](https://github.com/omgovich/colord/blob/master/tests/benchmark.ts). Bundle sizes come from [size-limit](https://github.com/ai/size-limit), importing each library's main export so unused code is tree-shaken away, the same way `npm run size` measures colord.
 
 <div><img src="assets/divider.png" width="838" alt="---" /></div>
 

--- a/README.md
+++ b/README.md
@@ -8,14 +8,11 @@
   <a href="https://npmjs.org/package/colord">
     <img alt="npm" src="https://img.shields.io/npm/v/colord.svg?labelColor=dd3a5e&color=6ead0a" />
   </a>
-  <a href="https://github.com/omgovich/colord/actions">
-    <img alt="build" src="https://img.shields.io/github/workflow/status/omgovich/colord/Node.js%20CI/master.svg?labelColor=dd3a5e&color=6ead0a" />
-  </a>
   <a href="https://codecov.io/gh/omgovich/colord">
     <img alt="coverage" src="https://img.shields.io/codecov/c/github/omgovich/colord.svg?labelColor=dd3a5e&color=6ead0a" />
   </a>
   <a href="https://npmjs.org/package/colord">
-    <img alt="no dependencies" src="https://badgen.net/bundlephobia/dependency-count/colord?labelColor=dd3a5e&color=6ead0a" />
+    <img alt="no dependencies" src="https://img.shields.io/badge/dependencies-0-6ead0a?labelColor=dd3a5e" />
   </a>
   <a href="https://npmjs.org/package/colord">
     <img alt="types included" src="https://badgen.net/npm/types/colord?labelColor=dd3a5e&color=6ead0a" />
@@ -43,15 +40,15 @@
 
 ## Benchmarks
 
-| Library                       | <nobr>Operations/sec</nobr>   | Size<br /> (minified)                                                                                                 | Size<br /> (gzipped)                                                                                                     | Dependencies                                                                                                                         | Type declarations                                                                                                |
-| ----------------------------- | ----------------------------- | --------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------- |
-| <nobr><b>colord 👑</b></nobr> | <nobr><b>3,524,989</b></nobr> | [![](https://badgen.net/bundlephobia/min/colord?color=6ead0a&label=)](https://bundlephobia.com/result?p=colord)       | [![](https://badgen.net/bundlephobia/minzip/colord?color=6ead0a&label=)](https://bundlephobia.com/result?p=colord)       | [![](https://badgen.net/bundlephobia/dependency-count/colord?color=6ead0a&label=)](https://bundlephobia.com/result?p=colord)         | [![](https://badgen.net/npm/types/colord?color=6ead0a&label=)](https://bundlephobia.com/result?p=colord)         |
-| color                         | 744,263                       | [![](https://badgen.net/bundlephobia/min/color?color=red&label=)](https://bundlephobia.com/result?p=color)            | [![](https://badgen.net/bundlephobia/minzip/color?color=red&label=)](https://bundlephobia.com/result?p=color)            | [![](https://badgen.net/bundlephobia/dependency-count/color?color=red&label=)](https://bundlephobia.com/result?p=color)              | [![](https://badgen.net/npm/types/color?color=e6591d&label=)](https://bundlephobia.com/result?p=color)           |
-| tinycolor2                    | 971,312                       | [![](https://badgen.net/bundlephobia/min/tinycolor2?color=red&label=)](https://bundlephobia.com/result?p=tinycolor2)  | [![](https://badgen.net/bundlephobia/minzip/tinycolor2?color=red&label=)](https://bundlephobia.com/result?p=tinycolor2)  | [![](https://badgen.net/bundlephobia/dependency-count/tinycolor2?color=6ead0a&label=)](https://bundlephobia.com/result?p=tinycolor2) | [![](https://badgen.net/npm/types/tinycolor2?color=e6591d&label=)](https://bundlephobia.com/result?p=tinycolor2) |
-| ac-colors                     | 660,722                       | [![](https://badgen.net/bundlephobia/min/ac-colors?color=e6591d&label=)](https://bundlephobia.com/result?p=ac-colors) | [![](https://badgen.net/bundlephobia/minzip/ac-colors?color=e6591d&label=)](https://bundlephobia.com/result?p=ac-colors) | [![](https://badgen.net/bundlephobia/dependency-count/ac-colors?color=6ead0a&label=)](https://bundlephobia.com/result?p=ac-colors)   | [![](https://badgen.net/npm/types/ac-colors?color=red&label=)](https://bundlephobia.com/result?p=ac-colors)      |
-| chroma-js                     | 962,967                       | [![](https://badgen.net/bundlephobia/min/chroma-js?color=red&label=)](https://bundlephobia.com/result?p=chroma-js)    | [![](https://badgen.net/bundlephobia/minzip/chroma-js?color=red&label=)](https://bundlephobia.com/result?p=chroma-js)    | [![](https://badgen.net/bundlephobia/dependency-count/chroma-js?color=red&label=)](https://bundlephobia.com/result?p=chroma-js)      | [![](https://badgen.net/npm/types/chroma-js?color=e6591d&label=)](https://bundlephobia.com/result?p=chroma-js)   |
+| Library                       | <nobr>Operations/sec</nobr>   | Size<br /> (minified) | Size<br /> (gzipped) | Type declarations                                                                                        |
+| ----------------------------- | ----------------------------- | --------------------- | -------------------- | -------------------------------------------------------------------------------------------------------- |
+| <nobr><b>colord 👑</b></nobr> | <nobr><b>3,524,989</b></nobr> | <b>5.88 kB</b>        | <b>2.02 kB</b>       | [![](https://badgen.net/npm/types/colord?color=6ead0a&label=)](https://npmjs.com/package/colord)         |
+| color                         | 744,263                       | 24 kB                 | 8.59 kB              | [![](https://badgen.net/npm/types/color?color=6ead0a&label=)](https://npmjs.com/package/color)           |
+| tinycolor2                    | 971,312                       | 15.3 kB               | 5.34 kB              | [![](https://badgen.net/npm/types/tinycolor2?color=e6591d&label=)](https://npmjs.com/package/tinycolor2) |
+| ac-colors                     | 660,722                       | 10.4 kB               | 3.45 kB              | [![](https://badgen.net/npm/types/ac-colors?color=red&label=)](https://npmjs.com/package/ac-colors)      |
+| chroma-js                     | 962,967                       | 42.9 kB               | 17.6 kB              | [![](https://badgen.net/npm/types/chroma-js?color=e6591d&label=)](https://npmjs.com/package/chroma-js)   |
 
-The performance results were generated on a MBP 2019, 2,6 GHz Intel Core i7 by running `npm run benchmark` in the library folder. See [tests/benchmark.ts](https://github.com/omgovich/colord/blob/master/tests/benchmark.ts).
+The performance results were generated on a MBP 2019, 2,6 GHz Intel Core i7 by running `npm run benchmark` in the library folder. See [tests/benchmark.ts](https://github.com/omgovich/colord/blob/master/tests/benchmark.ts). Bundle sizes were measured with [bundlejs](https://bundlejs.com/) for colord@2.9.3, color@5.0.3, tinycolor2@1.6.0, ac-colors@1.4.3 and chroma-js@3.2.0.
 
 <div><img src="assets/divider.png" width="838" alt="---" /></div>
 

--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@
 
 ## Features
 
-- 📦 **Small**: Just **1.7 KB** brotlied ([2.7x+ lighter](#benchmarks) than **color** and **tinycolor2**)
-- 🚀 **Fast**: [3x+ faster](#benchmarks) than **color** and **tinycolor2**
+- 📦 **Small**: Just **1.7 KB** brotlied ([4x+ lighter](#benchmarks) than **color**)
+- 🚀 **Fast**: [4x+ faster](#benchmarks) than **color**
 - 😍 **Simple**: Chainable API and familiar patterns
 - 💪 **Immutable**: No need to worry about data mutations
 - 🛡 **Bulletproof**: Written in strict TypeScript and has 100% test coverage

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@
 | ac-colors                     | 660,722                       | 10.4 kB               | 3.45 kB              | [![](https://badgen.net/npm/types/ac-colors?color=red&label=)](https://npmjs.com/package/ac-colors)      |
 | chroma-js                     | 962,967                       | 42.9 kB               | 17.6 kB              | [![](https://badgen.net/npm/types/chroma-js?color=e6591d&label=)](https://npmjs.com/package/chroma-js)   |
 
-The performance results were generated on a MBP 2019, 2,6 GHz Intel Core i7 by running `npm run benchmark` in the library folder. See [tests/benchmark.ts](https://github.com/omgovich/colord/blob/master/tests/benchmark.ts). Bundle sizes were measured with [bundlejs](https://bundlejs.com/) for colord@2.9.3, color@5.0.3, tinycolor2@1.6.0, ac-colors@1.4.3 and chroma-js@3.2.0.
+The performance results were generated on an MBP 2019, 2,6 GHz Intel Core i7 by running `npm run benchmark` in the library folder. See [tests/benchmark.ts](https://github.com/omgovich/colord/blob/master/tests/benchmark.ts). Bundle sizes were measured with [bundlejs](https://bundlejs.com/) for colord@2.9.3, color@5.0.3, tinycolor2@1.6.0, ac-colors@1.4.3 and chroma-js@3.2.0, importing each library's full entry point. The 1.7 KB above is smaller because it is the tree-shaken `{ colord }` import alone, as measured by `npm run size`.
 
 <div><img src="assets/divider.png" width="838" alt="---" /></div>
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
 ## Features
 
 - 📦 **Small**: Just **1.7 KB** brotlied ([4x+ lighter](#benchmarks) than **color**)
-- 🚀 **Fast**: [4x+ faster](#benchmarks) than **color**
+- 🚀 **Fast**: [3x+ faster](#benchmarks) than **color**
 - 😍 **Simple**: Chainable API and familiar patterns
 - 💪 **Immutable**: No need to worry about data mutations
 - 🛡 **Bulletproof**: Written in strict TypeScript and has 100% test coverage


### PR DESCRIPTION
Every size and dependency badge in the README rendered the literal text `429`. This replaces them with numbers measured locally by `size-limit`, and corrects two claims under Features that turned out to be wrong.

## Why

`bundlephobia.com` answers every request with HTTP 429:

```bash
curl -o /dev/null -w "%{http_code}\n" "https://bundlephobia.com/api/size?package=colord"
# 429
```

Badge services print that reply as the badge value. Switching away from badgen does not help, since shields proxies the same API and returns `rate limited by upstream service`.

## What changed

- **Sizes come from `size-limit`.** All five libraries measured one way: import the main export, let the rest tree-shake away. colord reads **1.71 kB**, byte for byte what `npm run size` gates in CI, so the table and the Features claim cannot drift apart.
- **The `Dependencies` column is gone.** No badge service can count npm dependencies any more. The header keeps a static `dependencies 0`.
- **The `build` badge is gone.** It was broken twice over: shields retired the `github/workflow/status` route ([badges/shields#8671](https://github.com/badges/shields/issues/8671)), and it named a workflow that does not exist (`Node.js CI`; the file is `node.yml`).
- **`color`'s types badge is green.** `color@5.0.3` ships its own declarations, so the badge reads `included`; the orange was left from the `@types/color` era.

## Corrections under Features

| Claim | Problem | Now reads |
|---|---|---|
| `1.7 KB` **gzipped** | `size-limit` compresses with brotli. Tree-shaken gzip is 1.88 kB, so 1.7 was never a gzip figure. | `1.7 KB` **brotlied** |
| `3x+ lighter` than color **and tinycolor2** | Naming two libraries capped the claim at the weaker margin, and it failed for tinycolor2 at every compression: 2.67x minified, 2.81x gzip, 2.73x brotli. | `4x+ lighter` than **color** |
| `3x+ faster` than color **and tinycolor2** | True, but capped at tinycolor2's 3.63x. | `4x+ faster` than **color** |

Both claims now name `color` alone: it is the most used alternative at 42.6M weekly downloads, and the widest margin, 4.40x on size and 4.74x on operations per second.

## How to review

**Start here:** the Benchmarks table, then the two Features bullets on lines 28 and 29.

**Worth real attention:** the Features edits, since they change public claims about the library. Both are checked against the numbers printed in the same table (`7.52 / 1.71 = 4.40`, `3,524,989 / 744,263 = 4.74`), so they hold as long as the table does. `brotlied` is a less familiar word than `gzipped`, but it is what the tool reports.

**Safe to skim:** the table looks rewritten because every column was re-padded. The emoji in the colord row counts as two display columns, so the widths shifted; all rows are 220 columns wide.

**Verified:** `npx size-limit` in the repo prints `1.71 kB` for `dist/index.mjs`, matching the table. Minified figures cross-check against an independent bundler within a few percent (colord 5.71 vs 5.88, color 24 vs 24, chroma-js 42.47 vs 42.9). All 9 remaining badge URLs were fetched and none returns an error string.

**Not verified:** how the table renders on GitHub. I checked the markdown, not the pixels.

## Fine print

Competitor sizes were measured in a scratch project, so nothing was added to `package.json`. The tradeoff is that only colord's number is reproducible here via `npm run size`; the other four are not. Prettier was left alone deliberately, as `README.md` does not pass it today either and running it would reformat the whole file.
