### PR TITLE
docs: add "Who Uses Colord" table and drop the Roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,25 @@ The performance results were generated on a MBP 2019, 2,6 GHz Intel Core i7 by r
 
 <div><img src="assets/divider.png" width="838" alt="---" /></div>
 
+## Who Uses Colord
+
+| Project                                                 | What it is                                                    | Reach                             |
+| ------------------------------------------------------- | ------------------------------------------------------------- | --------------------------------- |
+| **[GitLab](https://gitlab.com/gitlab-org/gitlab)**      | DevSecOps for the entire software lifecycle                   | <nobr>50M+ users</nobr>           |
+| **[WordPress](https://github.com/WordPress/gutenberg)** | Gutenberg, the editor inside every WordPress site             | <nobr>40% of all websites</nobr>  |
+| **[Stylelint](https://github.com/stylelint/stylelint)** | A mighty CSS linter                                           | <nobr>44M downloads/month</nobr>  |
+| **[cssnano](https://github.com/cssnano/cssnano)**       | The CSS minifier of the PostCSS world <nobr>(up to v6)</nobr> | <nobr>48M downloads/month</nobr>  |
+| **[pdf.net](https://pdf.net/)**                         | Everything you can do to a PDF, in the browser                | <nobr>4M+ users</nobr>            |
+| **[Gitea](https://github.com/go-gitea/gitea)**          | Self-hosted all-in-one software development service           | <nobr>57.5k ⭐</nobr>              |
+| **[PixiJS](https://github.com/pixijs/pixijs)**          | The fastest, most flexible 2D WebGL renderer                  | <nobr>48k ⭐</nobr>                |
+| **[Umami](https://github.com/umami-software/umami)**    | Analytics without the surveillance                            | <nobr>38k ⭐</nobr>                |
+| **[Documenso](https://github.com/documenso/documenso)** | The open source DocuSign                                      | <nobr>14.6k ⭐</nobr>              |
+| **[Leva](https://github.com/pmndrs/leva)**              | React-first GUI panel for live tweaking                       | <nobr>3.5M downloads/month</nobr> |
+
+...and [9.5 million more repositories](https://github.com/omgovich/colord/network/dependents) 🤯
+
+<div><img src="assets/divider.png" width="838" alt="---" /></div>
+
 ## Getting Started
 
 ```
@@ -1018,36 +1037,3 @@ import { RgbColor, RgbaColor, HslColor, HslaColor, HsvColor, HsvaColor } from "c
 const foo: HslColor = { h: 0, s: 0, l: 0 };
 const bar: RgbColor = { r: 0, g: 0, v: 0 }; // ERROR
 ```
-
-<div><img src="assets/divider.png" width="838" alt="---" /></div>
-
-## Projects using Colord
-
-- [cssnano](https://github.com/cssnano/cssnano) — the most popular CSS minification tool
-- [Resume.io](https://resume.io/) — online resume builder with over 12,000,000 users worldwide
-- [Leva](https://github.com/pmndrs/leva) — open source extensible GUI panel made for React
-- [Qui Max](https://github.com/Qvant-lab/qui-max) — Vue.js design system and component library
-- and [thousands more](https://github.com/omgovich/colord/network/dependents)...
-
-<div><img src="assets/divider.png" width="838" alt="---" /></div>
-
-## Roadmap
-
-- [x] Parse and convert Hex, RGB(A), HSL(A), HSV(A)
-- [x] Saturate, desaturate, grayscale
-- [x] Trim an input value
-- [x] Clamp input numbers to resolve edge cases (e.g. `rgb(256, -1, 999, 2)`)
-- [x] `brightness`, `isDark`, `isLight`
-- [x] Set and get `alpha`
-- [x] Plugin API
-- [x] 4 and 8 digit Hex
-- [x] `lighten`, `darken`
-- [x] `invert`
-- [x] CSS color names (via plugin)
-- [x] A11y and contrast utils (via plugin)
-- [x] XYZ color space (via plugin)
-- [x] [HWB](https://drafts.csswg.org/css-color/#the-hwb-notation) color space (via plugin)
-- [x] [LAB](https://www.w3.org/TR/css-color-4/#resolving-lab-lch-values) color space (via plugin)
-- [x] [LCH](https://lea.verou.me/2020/04/lch-colors-in-css-what-why-and-how/) color space (via plugin)
-- [x] Mix colors (via plugin)
-- [x] CMYK color space (via plugin)


### PR DESCRIPTION
Replaces the "Projects using Colord" list with a **Who Uses Colord** table, and moves it up to sit right after Benchmarks — so the social proof lands next to the performance numbers instead of at the very bottom of a 1000-line README.

Each row now carries a short description of the project and one popularity number, picking whichever metric is more meaningful (users, market share, npm downloads or stars).

## Why

The old list was four entries long and partly out of date: it led with cssnano, which no longer depends on colord, and ended with Qui Max, unmaintained since July 2024. Meanwhile GitLab, WordPress, Gitea and PixiJS have been using colord for a while with no mention anywhere.

## What changed

- **New entries**, each verified against the project's own `package.json` (`dependencies`, not lock files): GitLab, WordPress (Gutenberg), Stylelint, Gitea, PixiJS, Umami, Documenso. Leva stays.
- **cssnano is qualified as "up to v6"**. `postcss-colormin` switched from colord to a third-party fork in 7.0.7 (2026-03-30), and `cssnano-preset-default@7` resolves `postcss-colormin: ^7.0.x`, so a fresh cssnano 7 install no longer gets colord. Versions up to cssnano 6 still do — and that is still 48M downloads/month.
- **Dropped**: Qui Max (unmaintained), Resume.io (replaced by pdf.net).
- **Roadmap section removed.** Every item was already checked off, and the plugin-related ones (XYZ, HWB, LAB, LCH, CMYK, a11y) are documented in Plugins.

Note that PixiJS depends on `@pixi/colord` — colord republished under their own scope, same source and same author — and that Resume.io and pdf.net are closed source, so their entries rest on their own reports rather than a public manifest.

## How to review

The whole diff is one section of `README.md`, so reading the rendered file is easier than reading the diff.

**Worth checking:** the numbers, since they will age. Stars and downloads were read today from the GitHub and npm APIs. `50M+ users` for GitLab is from their [FY2026 10-K](https://www.sec.gov/Archives/edgar/data/1653482/000162828026018731/gtlb-20260131.htm) ("more than 50 million registered users"); `40% of all websites` for WordPress is [W3Techs](https://w3techs.com/technologies/details/cm-wordpress) (40.7%); `9.5 million more repositories` is GitHub's dependency graph (9,555,433).

**One derived number:** cssnano's 48M downloads/month. `postcss-colormin` gets 76.7M downloads/month, and 62.6% of its weekly downloads are on colord-based versions (≤7.0.6); npm only exposes the per-version split for the last week, so that share was applied to the monthly total. Everything else is a direct API reading.

**Safe to skim:** the table's source formatting — columns are space-padded for readability only.
