### PR TITLE
chore: add GitHub Sponsors to FUNDING.yml

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,1 +1,2 @@
+github: omgovich
 patreon: omgovich


### PR DESCRIPTION
GitHub Sponsors is now enabled for the maintainer account, so this adds `github: omgovich` to `.github/FUNDING.yml` alongside the existing Patreon entry. Once merged, the repo's Sponsor button will offer both options.

No code changes — a single line in the funding config.