### PR TITLE
chore: prepare the 2.9.5 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+### 2.9.5
+
+- Fix: Use adjusted chroma for the CIEDE2000 rotation term ❤️ [@maximilliangrand](https://github.com/maximilliangrand)
+- Fix: Keep the hue within `[0, 360)` in every color model ❤️ [@sarathfrancis90](https://github.com/sarathfrancis90)
+
+Both change returned numbers on a small set of colors; `toHex()` output is unchanged. Snapshots holding `h: 360`, `"hsl(360, …)"` or a `delta()` value may need updating.
+
 ### 2.9.4
 
 - Fix: Reject malformed color strings in linear time ❤️ [@GAP-dev](https://github.com/GAP-dev)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 - Fix: Use adjusted chroma for the CIEDE2000 rotation term ❤️ [@maximilliangrand](https://github.com/maximilliangrand)
 - Fix: Keep the hue within `[0, 360)` in every color model ❤️ [@sarathfrancis90](https://github.com/sarathfrancis90)
 
-Both change returned numbers on a small set of colors; `toHex()` output is unchanged. Snapshots holding `h: 360`, `"hsl(360, …)"` or a `delta()` value may need updating.
+Both fixes change returned numbers for a small set of colors; `toHex()` output is unchanged. Snapshots holding `h: 360`, `"hsl(360, …)"` or a `delta()` value may need updating.
 
 ### 2.9.4
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "colord",
-  "version": "2.9.4",
+  "version": "2.9.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "colord",
-      "version": "2.9.4",
+      "version": "2.9.5",
       "license": "MIT",
       "devDependencies": {
         "@size-limit/preset-small-lib": "^11.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "colord",
-  "version": "2.9.4",
+  "version": "2.9.5",
   "description": "👑 A tiny yet powerful tool for high-performance color manipulations and conversions",
   "keywords": [
     "color",


### PR DESCRIPTION
Release prep for 2.9.5: the changelog entry and the version bump.

```
### 2.9.5

- Fix: Use adjusted chroma for the CIEDE2000 rotation term ❤️ @maximilliangrand
- Fix: Keep the hue within `[0, 360)` in every color model ❤️ @sarathfrancis90

Both change returned numbers on a small set of colors; `toHex()` output is unchanged. Snapshots holding `h: 360`, `"hsl(360, …)"` or a `delta()` value may need updating.
```

`package.json` and `package-lock.json` go from 2.9.4 to 2.9.5 — the same three lines the 2.9.4 bump touched, via `npm version --no-git-tag-version`.

## Why the extra sentence in the entry

Both fixes change values the library returns, so consumers with stored expectations can break. The version number cannot warn them: nearly everyone depends via `^2.9.x`, and caret ranges pick up patches and minors alike — only a major would gate it, and that is disproportionate for two bug fixes. So the one mitigation that actually works is naming the symptom a consumer will grep for when a snapshot fails.

Scope of each change, measured:

- **CIEDE2000** — `delta()` moves by up to 0.031 on the 0–1 scale, only where the mean hue sits near 275° and both chromas are high. Nearest-colour searches are effectively unaffected: over 262144 queries against a 16-colour palette the winner changed twice, both exact ties after rounding.
- **Hue wrap** — the hue *number* changes for 9452 of the 16.7M 8-bit colours (0.056%), plus 149 in LCH. No colour changes: `toHex`, `toRgb` and everything derived from RGB are identical across a 71248-observation diff of the whole public API and all ten plugins.

## Notes for review

- **Merge after #136.** The second bullet credits a PR that is still open. #140 is already on master.
- The interval is in backticks because a bare `[0, 360)` trips naive Markdown highlighters in editors. GitHub itself renders it as plain text either way; I checked via the render API.
