### PR TITLE
fix: rotate the unrounded hue so harmonies preserve the original color

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,7 +67,7 @@ When writing parsing regexes, spell numbers as `(?:\d*\.\d+|\d+)`, never `\d*\.?
 
 Release conventions:
 
-- Every release, including patches, gets a CHANGELOG.md entry (newest on top), crediting the contributor: `- Fix: ... ❤️ [@user](https://github.com/user)`. Keep fix entries compact — one bullet per fix, no explanatory paragraphs; the details live in the PR.
+- Every release, including patches, gets a CHANGELOG.md entry (newest on top), crediting the code contributor (the PR author, not the issue reporter): `- Fix: ... ❤️ [@user](https://github.com/user)`. Keep fix entries compact — one bullet per fix, no explanatory paragraphs; the details live in the PR.
 - Patch releases are **not** tagged in the repo. Minor and major releases get a git tag (`v2.9` — no patch digit) and a GitHub Release.
 
 ## Testing

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,7 +67,7 @@ When writing parsing regexes, spell numbers as `(?:\d*\.\d+|\d+)`, never `\d*\.?
 
 Release conventions:
 
-- Every release, including patches, gets a CHANGELOG.md entry (newest on top), crediting the contributor: `- Fix: ... ❤️ [@user](https://github.com/user)`.
+- Every release, including patches, gets a CHANGELOG.md entry (newest on top), crediting the contributor: `- Fix: ... ❤️ [@user](https://github.com/user)`. Keep fix entries compact — one bullet per fix, no explanatory paragraphs; the details live in the PR.
 - Patch releases are **not** tagged in the repo. Minor and major releases get a git tag (`v2.9` — no patch digit) and a GitHub Release.
 
 ## Testing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,6 @@
 
 - Fix: Rotate the unrounded hue so `rotate` and `harmonies` preserve the original color ❤️ [@jfagan1](https://github.com/jfagan1)
 
-`rotate()` (and every `harmonies()` shift) no longer snaps the hue to a whole degree, so its output changes for colors whose hue isn't a whole degree — e.g. the complementary of `#03ff84` is now `#ff037e` instead of `#ff037d`, and a zero rotation returns the color unchanged.
-
 ### 2.9.5
 
 - Fix: Use adjusted chroma for the CIEDE2000 rotation term ❤️ [@maximilliangrand](https://github.com/maximilliangrand)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+### 2.9.6
+
+- Fix: Rotate the unrounded hue so `rotate` and `harmonies` preserve the original color ❤️ [@jfagan1](https://github.com/jfagan1)
+
+`rotate()` (and every `harmonies()` shift) no longer snaps the hue to a whole degree, so its output changes for colors whose hue isn't a whole degree — e.g. the complementary of `#03ff84` is now `#ff037e` instead of `#ff037d`, and a zero rotation returns the color unchanged.
+
 ### 2.9.5
 
 - Fix: Use adjusted chroma for the CIEDE2000 rotation term ❤️ [@maximilliangrand](https://github.com/maximilliangrand)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ### 2.9.6
 
-- Fix: Rotate the unrounded hue so `rotate` and `harmonies` preserve the original color ❤️ [@jfagan1](https://github.com/jfagan1)
+- Fix: Rotate the unrounded hue so `rotate` and `harmonies` preserve the original color
 
 ### 2.9.5
 

--- a/src/colord.ts
+++ b/src/colord.ts
@@ -151,7 +151,9 @@ export class Colord {
    * Changes the HSL hue of a color by the given amount.
    */
   public rotate(amount = 15): Colord {
-    return this.hue(this.hue() + amount);
+    // Shift the unrounded hue: reading it through the `hue()` getter rounds it
+    // to a whole degree, which perturbs the other channels (issue #123).
+    return this.hue(rgbaToHsla(this.rgba).h + amount);
   }
 
   /**

--- a/src/colord.ts
+++ b/src/colord.ts
@@ -151,8 +151,7 @@ export class Colord {
    * Changes the HSL hue of a color by the given amount.
    */
   public rotate(amount = 15): Colord {
-    // Shift the unrounded hue: reading it through the `hue()` getter rounds it
-    // to a whole degree, which perturbs the other channels (issue #123).
+    // Shift the unrounded hue: the `hue()` getter rounds it, perturbing the color (issue #123)
     return this.hue(rgbaToHsla(this.rgba).h + amount);
   }
 

--- a/src/plugins/harmonies.ts
+++ b/src/plugins/harmonies.ts
@@ -37,7 +37,9 @@ const harmoniesPlugin: Plugin = (ColordClass): void => {
   };
 
   ColordClass.prototype.harmonies = function (type = "complementary") {
-    return hueShifts[type].map((shift) => this.rotate(shift));
+    // The instances are immutable, so the zero shift can return the original
+    // color instead of paying for an HSL round trip.
+    return hueShifts[type].map((shift) => (shift ? this.rotate(shift) : this));
   };
 };
 

--- a/src/plugins/harmonies.ts
+++ b/src/plugins/harmonies.ts
@@ -37,8 +37,7 @@ const harmoniesPlugin: Plugin = (ColordClass): void => {
   };
 
   ColordClass.prototype.harmonies = function (type = "complementary") {
-    // The instances are immutable, so the zero shift can return the original
-    // color instead of paying for an HSL round trip.
+    // The zero shift returns the original color: instances are immutable, and it skips an HSL round trip
     return hueShifts[type].map((shift) => (shift ? this.rotate(shift) : this));
   };
 };

--- a/tests/colord.test.ts
+++ b/tests/colord.test.ts
@@ -346,6 +346,14 @@ it("Rotates a hue circle", () => {
   expect(colord("hsl(90, 50%, 50%)").rotate(-180).toHslString()).toBe("hsl(270, 50%, 50%)");
 });
 
+it("Preserves a color with a non-integer hue while rotating", () => {
+  // https://github.com/omgovich/colord/issues/123
+  // "#03ff84" has a hue of ~150.71 degrees. `rotate` must not snap it to 151.
+  expect(colord("#03ff84").rotate(0).toHex()).toBe("#03ff84");
+  expect(colord("#03ff84").rotate(360).toHex()).toBe("#03ff84");
+  expect(colord("#03ff84").rotate(180).rotate(180).toHex()).toBe("#03ff84");
+});
+
 it("Checks colors for equality", () => {
   const otherColor = "#1ab2c3";
   const otherInstance = colord(otherColor);

--- a/tests/colord.test.ts
+++ b/tests/colord.test.ts
@@ -347,8 +347,7 @@ it("Rotates a hue circle", () => {
 });
 
 it("Preserves a color with a non-integer hue while rotating", () => {
-  // https://github.com/omgovich/colord/issues/123
-  // "#03ff84" has a hue of ~150.71 degrees. `rotate` must not snap it to 151.
+  // https://github.com/omgovich/colord/issues/123 — the hue (~150.71) must not snap to 151
   expect(colord("#03ff84").rotate(0).toHex()).toBe("#03ff84");
   expect(colord("#03ff84").rotate(360).toHex()).toBe("#03ff84");
   expect(colord("#03ff84").rotate(180).rotate(180).toHex()).toBe("#03ff84");

--- a/tests/plugins.test.ts
+++ b/tests/plugins.test.ts
@@ -118,6 +118,25 @@ describe("harmonies", () => {
     check("triadic", "#ff0000", ["#ff0000", "#00ff00", "#0000ff"]);
     check("split-complementary", "#ff0000", ["#ff0000", "#00ff80", "#0080ff"]);
   });
+
+  it("Preserves an input color with a non-integer hue", () => {
+    // https://github.com/omgovich/colord/issues/123
+    // "#03ff84" has a hue of ~150.71 degrees, so rounding it to 151 while
+    // rotating used to mutate the original color to "#03ff85".
+    check("analogous", "#03ff84", ["#03ff06", "#03ff84", "#03fcff"]);
+    check("complementary", "#03ff84", ["#03ff84", "#ff037e"]);
+    check("double-split-complementary", "#03ff84", [
+      "#03ff06",
+      "#03ff84",
+      "#03fcff",
+      "#ff03fc",
+      "#ff0603",
+    ]);
+    check("rectangle", "#03ff84", ["#03ff84", "#037eff", "#ff037e", "#ff8403"]);
+    check("tetradic", "#03ff84", ["#03ff84", "#0603ff", "#ff037e", "#fcff03"]);
+    check("triadic", "#03ff84", ["#03ff84", "#8403ff", "#ff8403"]);
+    check("split-complementary", "#03ff84", ["#03ff84", "#ff03fc", "#ff0603"]);
+  });
 });
 
 describe("hwb", () => {

--- a/tests/plugins.test.ts
+++ b/tests/plugins.test.ts
@@ -120,9 +120,7 @@ describe("harmonies", () => {
   });
 
   it("Preserves an input color with a non-integer hue", () => {
-    // https://github.com/omgovich/colord/issues/123
-    // "#03ff84" has a hue of ~150.71 degrees, so rounding it to 151 while
-    // rotating used to mutate the original color to "#03ff85".
+    // https://github.com/omgovich/colord/issues/123 — hue rounding used to mutate the input color
     check("analogous", "#03ff84", ["#03ff06", "#03ff84", "#03fcff"]);
     check("complementary", "#03ff84", ["#03ff84", "#ff037e"]);
     check("double-split-complementary", "#03ff84", [


### PR DESCRIPTION
Fixes #123.

## Why

`colord("#03FF84").harmonies("complementary")` returned `["#03FF85", "#FF037D"]` — the original color itself came back mutated. Every harmony type was affected, because they all go through `rotate()`.

## Root cause

`rotate()` was implemented as `this.hue(this.hue() + amount)`, and the public `hue()` getter rounds the hue to a whole degree. `#03FF84` has a true hue of ~150.71°, so even the 0° shift rebuilt the color from a snapped 151° hue, shifting the green channel by one step.

## The fix

- `rotate()` now shifts the unrounded hue taken directly from `rgbaToHsla(this.rgba)` instead of going through the rounded getter. The public `hue()` getter and setter are untouched, so their observable behavior doesn't change — only `rotate()` (and therefore `harmonies()`) output changes, and only for colors whose hue isn't a whole degree, which is the bug being fixed.
- `harmonies()` returns the original instance for the zero shift instead of paying for an HSL round trip. The instances are immutable, so sharing is safe, and this makes "the base color comes back unchanged" a guarantee by construction rather than a numerical accident.

Size cost is negligible: all `size-limit` budgets pass (main bundle 1.72 kB of 2 kB, harmonies plugin 201 B of 500 B).

## Tests

- `tests/colord.test.ts`: `rotate(0)`, `rotate(360)`, and `rotate(180).rotate(180)` are identity operations on `#03ff84`.
- `tests/plugins.test.ts`: all seven harmony types for `#03ff84`, pinning that the input color survives unchanged.

`lint`, `check-types`, `test` (612 passing, 100% coverage), and `size` are all green locally. Also fuzzed `rotate(0)` identity over ~120k colors (integer RGB cube sample plus fractional HSL inputs) with zero mismatches.
