### PR TITLE
feat: add an optional RGB interpolation mode to the mix plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 2.10.0
+
+- Improve `mix` plugin by adding an optional `"rgb"` interpolation mode to `mix`, `tints`, `tones` and `shades`
+
 ### 2.9.7
 
 - Make HEX parsing and serialization more than 2x faster

--- a/README.md
+++ b/README.md
@@ -497,11 +497,13 @@ colord("hsl(90, 50%, 50%)").rotate(-180).toHslString(); // "hsl(270, 50%, 50%)"
 </details>
 
 <details>
-  <summary><b><code>.mix(color2, ratio = 0.5)</code></b> (<b>mix</b> plugin)</summary>
+  <summary><b><code>.mix(color2, ratio = 0.5, space = "lab")</code></b> (<b>mix</b> plugin)</summary>
 
 Produces a mixture of two colors and returns the result of mixing them (new Colord instance).
 
-In contrast to other libraries that perform RGB values mixing, Colord mixes colors through [LAB color space](https://en.wikipedia.org/wiki/CIELAB_color_space). This approach produces better results and doesn't have the drawbacks the legacy way has.
+In contrast to other libraries that perform RGB values mixing, Colord mixes colors through [LAB color space](https://en.wikipedia.org/wiki/CIELAB_color_space) by default. This approach produces better results and doesn't have the drawbacks the legacy way has.
+
+Pass `"rgb"` as the third argument to interpolate RGB channels instead. This mode matches the way browsers and design tools (such as Figma) composite translucent layers: mixing a background with an overlay color at the overlay's opacity gives the same result as alpha compositing.
 
 → [Online demo](https://3cg7o.csb.app/)
 
@@ -515,14 +517,18 @@ colord("#ffffff").mix("#000000").toHex(); // "#777777"
 colord("#800080").mix("#dda0dd").toHex(); // "#af5cae"
 colord("#cd853f").mix("#eee8aa", 0.6).toHex(); // "#e3c07e"
 colord("#008080").mix("#808000", 0.35).toHex(); // "#50805d"
+
+// RGB interpolation (matches alpha compositing in browsers and design tools)
+colord("#ff0000").mix("#ffffff", 0.5, "rgb").toHex(); // "#ff8080"
+colord("#f0f3f1").mix("#007d40", 0.14, "rgb").toHex(); // "#cee2d8"
 ```
 
 </details>
 
 <details>
-  <summary><b><code>.tints(count = 5)</code></b> (<b>mix</b> plugin)</summary>
+  <summary><b><code>.tints(count = 5, space = "lab")</code></b> (<b>mix</b> plugin)</summary>
 
-Provides functionality to generate [tints](https://en.wikipedia.org/wiki/Tints_and_shades) of a color. Returns an array of `Colord` instances, including the original color.
+Provides functionality to generate [tints](https://en.wikipedia.org/wiki/Tints_and_shades) of a color. Returns an array of `Colord` instances, including the original color. Mixes through LAB color space by default; pass `"rgb"` to interpolate RGB channels instead.
 
 ```js
 import { colord, extend } from "colord";
@@ -537,9 +543,9 @@ color.tints(3).map((c) => c.toHex()); // ["#ff0000", "#ff9f80", "#ffffff"];
 </details>
 
 <details>
-  <summary><b><code>.shades(count = 5)</code></b> (<b>mix</b> plugin)</summary>
+  <summary><b><code>.shades(count = 5, space = "lab")</code></b> (<b>mix</b> plugin)</summary>
 
-Provides functionality to generate [shades](https://en.wikipedia.org/wiki/Tints_and_shades) of a color. Returns an array of `Colord` instances, including the original color.
+Provides functionality to generate [shades](https://en.wikipedia.org/wiki/Tints_and_shades) of a color. Returns an array of `Colord` instances, including the original color. Mixes through LAB color space by default; pass `"rgb"` to interpolate RGB channels instead.
 
 ```js
 import { colord, extend } from "colord";
@@ -554,9 +560,9 @@ color.shades(3).map((c) => c.toHex()); // ["#ff0000", "#7a1b0b", "#000000"];
 </details>
 
 <details>
-  <summary><b><code>.tones(count = 5)</code></b> (<b>mix</b> plugin)</summary>
+  <summary><b><code>.tones(count = 5, space = "lab")</code></b> (<b>mix</b> plugin)</summary>
 
-Provides functionality to generate [tones](https://en.wikipedia.org/wiki/Tints_and_shades) of a color. Returns an array of `Colord` instances, including the original color.
+Provides functionality to generate [tones](https://en.wikipedia.org/wiki/Tints_and_shades) of a color. Returns an array of `Colord` instances, including the original color. Mixes through LAB color space by default; pass `"rgb"` to interpolate RGB channels instead.
 
 ```js
 import { colord, extend } from "colord";
@@ -948,11 +954,11 @@ colord("rgba(170,170,170,0.4)").minify({ alphaHex: true }); // "#aaa6"
 </details>
 
 <details>
-  <summary><b><code>mix</code> (Color mixing)</b> <i>0.96 KB</i></summary>
+  <summary><b><code>mix</code> (Color mixing)</b> <i>1.01 KB</i></summary>
 
 A plugin adding color mixing utilities.
 
-In contrast to other libraries that perform RGB values mixing, Colord mixes colors through [LAB color space](https://en.wikipedia.org/wiki/CIELAB_color_space). This approach produces better results and doesn't have the drawbacks the legacy way has.
+In contrast to other libraries that perform RGB values mixing, Colord mixes colors through [LAB color space](https://en.wikipedia.org/wiki/CIELAB_color_space) by default. This approach produces better results and doesn't have the drawbacks the legacy way has. If you need to match the alpha compositing of browsers and design tools instead, pass `"rgb"` as the last argument to interpolate RGB channels.
 
 → [Online demo](https://3cg7o.csb.app/)
 
@@ -966,6 +972,7 @@ colord("#ffffff").mix("#000000").toHex(); // "#777777"
 colord("#800080").mix("#dda0dd").toHex(); // "#af5cae"
 colord("#cd853f").mix("#eee8aa", 0.6).toHex(); // "#e3c07e"
 colord("#008080").mix("#808000", 0.35).toHex(); // "#50805d"
+colord("#ff0000").mix("#ffffff", 0.5, "rgb").toHex(); // "#ff8080"
 ```
 
 Also, the plugin provides special mixtures such as [tints, shades, and tones](https://en.wikipedia.org/wiki/Tints_and_shades):

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "colord",
-  "version": "2.9.7",
+  "version": "2.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "colord",
-      "version": "2.9.7",
+      "version": "2.10.0",
       "license": "MIT",
       "devDependencies": {
         "@size-limit/preset-small-lib": "^11.2.0",

--- a/package.json
+++ b/package.json
@@ -199,7 +199,7 @@
     },
     {
       "path": "dist/plugins/mix.mjs",
-      "limit": "1 KB"
+      "limit": "1.1 KB"
     },
     {
       "path": "dist/plugins/names.mjs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "colord",
-  "version": "2.9.7",
+  "version": "2.10.0",
   "description": "👑 A tiny yet powerful tool for high-performance color manipulations and conversions",
   "keywords": [
     "color",

--- a/src/manipulate/mix.ts
+++ b/src/manipulate/mix.ts
@@ -1,15 +1,35 @@
 import { clampLaba, labaToRgba, rgbaToLaba } from "../colorModels/lab";
 import { RgbaColor } from "../types";
 
-export const mix = (rgba1: RgbaColor, rgba2: RgbaColor, ratio: number): RgbaColor => {
+export type MixingColorSpace = "lab" | "rgb";
+
+export const mix = (
+  rgba1: RgbaColor,
+  rgba2: RgbaColor,
+  ratio: number,
+  space?: MixingColorSpace
+): RgbaColor => {
+  const interpolate = (start: number, end: number): number => start + (end - start) * ratio;
+
+  // RGB interpolation matches the alpha compositing of browsers and design tools.
+  // No clamping needed: the plugin passes the result through the RGB parser, which clamps
+  if (space === "rgb") {
+    return {
+      r: interpolate(rgba1.r, rgba2.r),
+      g: interpolate(rgba1.g, rgba2.g),
+      b: interpolate(rgba1.b, rgba2.b),
+      a: interpolate(rgba1.a, rgba2.a),
+    };
+  }
+
   const laba1 = rgbaToLaba(rgba1);
   const laba2 = rgbaToLaba(rgba2);
 
   const mixture = clampLaba({
-    l: laba1.l * (1 - ratio) + laba2.l * ratio,
-    a: laba1.a * (1 - ratio) + laba2.a * ratio,
-    b: laba1.b * (1 - ratio) + laba2.b * ratio,
-    alpha: laba1.alpha * (1 - ratio) + laba2.alpha * ratio,
+    l: interpolate(laba1.l, laba2.l),
+    a: interpolate(laba1.a, laba2.a),
+    b: interpolate(laba1.b, laba2.b),
+    alpha: interpolate(laba1.alpha, laba2.alpha),
   });
 
   return labaToRgba(mixture);

--- a/src/plugins/mix.ts
+++ b/src/plugins/mix.ts
@@ -1,29 +1,32 @@
 import { AnyColor } from "../types";
 import { Plugin } from "../extend";
-import { mix } from "../manipulate/mix";
+import { mix, MixingColorSpace } from "../manipulate/mix";
 import { Colord } from "../colord";
 
 declare module "../colord" {
   interface Colord {
     /**
-     * Produces a mixture of two colors through CIE LAB color space and returns a new Colord instance.
+     * Produces a mixture of two colors and returns a new Colord instance.
+     * Mixes through CIE LAB color space by default;
+     * pass "rgb" to interpolate RGB channels instead
+     * (the way browsers and design tools composite translucent layers).
      */
-    mix(color2: AnyColor | Colord, ratio?: number): Colord;
+    mix(color2: AnyColor | Colord, ratio?: number, space?: MixingColorSpace): Colord;
 
     /**
      * Generates a tints palette based on original color.
      */
-    tints(count?: number): Colord[];
+    tints(count?: number, space?: MixingColorSpace): Colord[];
 
     /**
      * Generates a shades palette based on original color.
      */
-    shades(count?: number): Colord[];
+    shades(count?: number, space?: MixingColorSpace): Colord[];
 
     /**
      * Generates a tones palette based on original color.
      */
-    tones(count?: number): Colord[];
+    tones(count?: number, space?: MixingColorSpace): Colord[];
   }
 }
 
@@ -31,35 +34,35 @@ declare module "../colord" {
  * A plugin adding a color mixing utilities.
  */
 const mixPlugin: Plugin = (ColordClass): void => {
-  ColordClass.prototype.mix = function (color2, ratio = 0.5) {
+  ColordClass.prototype.mix = function (color2, ratio = 0.5, space) {
     const instance2 = color2 instanceof ColordClass ? color2 : new ColordClass(color2);
 
-    const mixture = mix(this.toRgb(), instance2.toRgb(), ratio);
+    const mixture = mix(this.toRgb(), instance2.toRgb(), ratio, space);
     return new ColordClass(mixture);
   };
 
   /**
    * Generate a palette from mixing a source color with another.
    */
-  function mixPalette(source: Colord, hex: string, count = 5): Colord[] {
+  function mixPalette(source: Colord, hex: string, count = 5, space?: MixingColorSpace): Colord[] {
     const palette = [];
     const step = 1 / (count - 1);
     for (let i = 0; i <= count - 1; i++) {
-      palette.push(source.mix(hex, step * i));
+      palette.push(source.mix(hex, step * i, space));
     }
     return palette;
   }
 
-  ColordClass.prototype.tints = function (count) {
-    return mixPalette(this, "#fff", count);
+  ColordClass.prototype.tints = function (count, space) {
+    return mixPalette(this, "#fff", count, space);
   };
 
-  ColordClass.prototype.shades = function (count) {
-    return mixPalette(this, "#000", count);
+  ColordClass.prototype.shades = function (count, space) {
+    return mixPalette(this, "#000", count, space);
   };
 
-  ColordClass.prototype.tones = function (count) {
-    return mixPalette(this, "#808080", count);
+  ColordClass.prototype.tones = function (count, space) {
+    return mixPalette(this, "#808080", count, space);
   };
 };
 

--- a/tests/plugins.test.ts
+++ b/tests/plugins.test.ts
@@ -376,6 +376,7 @@ describe("mix", () => {
 
   it("Mixes two colors", () => {
     expect(colord("#000000").mix("#ffffff").toHex()).toBe("#777777");
+    expect(colord("#000000").mix(colord("#ffffff")).toHex()).toBe("#777777");
     expect(colord("#dc143c").mix("#000000").toHex()).toBe("#6a1b21");
     expect(colord("#800080").mix("#dda0dd").toHex()).toBe("#af5cae");
     expect(colord("#228b22").mix("#87cefa").toHex()).toBe("#60ac8f");
@@ -417,6 +418,32 @@ describe("mix", () => {
     check(colord("#ff0000").tones(3), ["#ff0000", "#c86147", "#808080"]);
     check(colord("#ff0000").tones(), ["#ff0000", "#e54729", "#c86147", "#a87363", "#808080"]);
     expect(colord("#aabbcc").tones(987)).toHaveLength(987);
+  });
+
+  it("Mixes two colors through RGB color space", () => {
+    // https://github.com/omgovich/colord/issues/106
+    expect(colord("#ff0000").mix("#ffffff", 0.25, "rgb").toHex()).toBe("#ff4040");
+    expect(colord("#ff0000").mix("#ffffff", 0.5, "rgb").toHex()).toBe("#ff8080");
+    expect(colord("#ff0000").mix("#ffffff", 0.75, "rgb").toHex()).toBe("#ffbfbf");
+    // https://github.com/omgovich/colord/issues/126
+    // matches the alpha compositing of a `rgba(0, 125, 64, 0.14)` layer over `#f0f3f1`
+    expect(colord("#f0f3f1").mix("#007d40", 0.14, "rgb").toHex()).toBe("#cee2d8");
+  });
+
+  it("Interpolates alpha channel in RGB color space", () => {
+    expect(colord("rgba(0, 0, 0, 1)").mix("rgba(255, 255, 255, 0)", 0.5, "rgb").toRgbString()).toBe(
+      "rgba(128, 128, 128, 0.5)"
+    );
+  });
+
+  it("Mixes through LAB when the space is set explicitly", () => {
+    expect(colord("#000000").mix("#ffffff", 0.5, "lab").toHex()).toBe("#777777");
+  });
+
+  it("Generates palettes through RGB color space", () => {
+    check(colord("#ff0000").tints(3, "rgb"), ["#ff0000", "#ff8080", "#ffffff"]);
+    check(colord("#ff0000").shades(3, "rgb"), ["#ff0000", "#800000", "#000000"]);
+    check(colord("#ff0000").tones(3, "rgb"), ["#ff0000", "#c04040", "#808080"]);
   });
 });
 


### PR DESCRIPTION
Fixes #106, fixes #126.

## What

Adds an optional interpolation color space argument to the **mix** plugin. LAB stays the default, so existing output is unchanged:

```js
colord("#ff0000").mix("#ffffff", 0.5);        // LAB, same as before
colord("#ff0000").mix("#ffffff", 0.5, "rgb"); // "#ff8080" — RGB interpolation
colord("#ff0000").tints(3, "rgb");            // palettes accept it too
```

`tints`, `shades`, and `tones` take the same argument, since they mix under the hood.

## Why

Both issues come from the same root cause: `mix` interpolates in CIE LAB, which

- isn't hue-linear, so red mixed with white drifts orange-ish (#106);
- is a different operation from the alpha compositing browsers and design tools perform, so results can't match a flattened translucent layer from Figma (#126).

The `"rgb"` mode is a plain per-channel lerp — for opaque colors it's exactly equivalent to alpha compositing, so `colord("#f0f3f1").mix("#007d40", 0.14, "rgb")` now reproduces Figma's `#cee2d8` from #126. Changing the *default* to RGB (or OKLab) would silently change output for every existing `mix`/`tints`/`shades`/`tones` caller, so the default stays LAB.

## Notes for review

- The `"rgb"` branch in `src/manipulate/mix.ts` returns unclamped values on purpose: the plugin feeds the result through `new ColordClass()`, whose RGB parser clamps. A comment marks this.
- The feature costs ~60 B; the plugin was already at 950 B of its 1 KB budget, so the `size-limit` entry is now 1.1 KB (actual: 1.01 KB).
- Tests pin the exact values reported in both issues; the pre-existing LAB expectations are untouched and still pass.
- `lint`, `check-types`, `test` (100% coverage), and `size` all pass locally.
