### PR TITLE
feat: add OKLab and OKLCH plugins

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ dist/
 # OSX
 .DS_Store
 .LSOverride
+/docs/superpowers

--- a/README.md
+++ b/README.md
@@ -98,6 +98,8 @@ colord("hsl(0, 50%, 50%)").darken(0.25).toHex(); // "#602020"
 - CMYK objects and strings ([via plugin](#plugins))
 - LCH objects and strings ([via plugin](#plugins))
 - LAB objects ([via plugin](#plugins))
+- OKLCH objects and strings ([via plugin](#plugins))
+- OKLab objects and strings ([via plugin](#plugins))
 - XYZ objects ([via plugin](#plugins))
 
 <div><img src="assets/divider.png" width="838" alt="---" /></div>
@@ -365,6 +367,74 @@ extend([lchPlugin]);
 
 colord("#ffffff").toLchString(); // "lch(100% 0 0)"
 colord("#213b0b").alpha(0.5).toLchString(); // "lch(21.85% 31.95 127.77 / 0.5)"
+```
+
+</details>
+
+<details>
+  <summary><b><code>.toOklab()</code></b> (<b>oklab</b> plugin)</summary>
+
+Converts a color to [OKLab](https://bottosson.github.io/posts/oklab/) color space. The returned object carries an `ok: true` marker that distinguishes it from a CIE LAB object (both use the same `l`/`a`/`b` channel keys), so it can be safely passed back to `colord`.
+
+```js
+import { colord, extend } from "colord";
+import oklabPlugin from "colord/plugins/oklab";
+
+extend([oklabPlugin]);
+
+colord("#ffffff").toOklab(); // { l: 1, a: 0, b: 0, alpha: 1, ok: true }
+colord("#ff6347").toOklab(); // { l: 0.6962, a: 0.1652, b: 0.1045, alpha: 1, ok: true }
+```
+
+</details>
+
+<details>
+  <summary><b><code>.toOklabString()</code></b> (<b>oklab</b> plugin)</summary>
+
+Converts a color to [OKLab](https://bottosson.github.io/posts/oklab/) color space and expresses it through the [functional notation](https://www.w3.org/TR/css-color-4/#specifying-oklab-oklch).
+
+```js
+import { colord, extend } from "colord";
+import oklabPlugin from "colord/plugins/oklab";
+
+extend([oklabPlugin]);
+
+colord("#ffffff").toOklabString(); // "oklab(1 0 0)"
+colord("#ff6347").toOklabString(); // "oklab(0.6962 0.1652 0.1045)"
+```
+
+</details>
+
+<details>
+  <summary><b><code>.toOklch()</code></b> (<b>oklch</b> plugin)</summary>
+
+Converts a color to [OKLCH](https://evilmartians.com/chronicles/oklch-in-css-why-quit-rgb-hsl) color space. The returned object carries an `ok: true` marker that distinguishes it from a CIE LCH object (both use the same `l`/`c`/`h` channel keys), so it can be safely passed back to `colord`.
+
+```js
+import { colord, extend } from "colord";
+import oklchPlugin from "colord/plugins/oklch";
+
+extend([oklchPlugin]);
+
+colord("#ffffff").toOklch(); // { l: 1, c: 0, h: 0, a: 1, ok: true }
+colord("#008080").toOklch(); // { l: 0.5431, c: 0.0927, h: 194.77, a: 1, ok: true }
+```
+
+</details>
+
+<details>
+  <summary><b><code>.toOklchString()</code></b> (<b>oklch</b> plugin)</summary>
+
+Converts a color to [OKLCH](https://evilmartians.com/chronicles/oklch-in-css-why-quit-rgb-hsl) color space and expresses it through the [functional notation](https://www.w3.org/TR/css-color-4/#specifying-oklab-oklch).
+
+```js
+import { colord, extend } from "colord";
+import oklchPlugin from "colord/plugins/oklch";
+
+extend([oklchPlugin]);
+
+colord("#ffffff").toOklchString(); // "oklch(1 0 0)"
+colord("#008080").alpha(0.5).toOklchString(); // "oklch(0.5431 0.0927 194.77 / 0.5)"
 ```
 
 </details>
@@ -999,6 +1069,50 @@ colord("#00ffff").toName(); // "cyan"
 colord("rgba(0, 0, 0, 0)").toName(); // "transparent"
 colord("#fe0000").toName(); // undefined (the color is not specified in CSS specs)
 colord("#fe0000").toName({ closest: true }); // "red" (closest color)
+```
+
+</details>
+
+<details>
+  <summary><b><code>oklab</code> (OKLab color space)</b> <i>1.04 KB</i></summary>
+
+Adds support of [OKLab](https://bottosson.github.io/posts/oklab/) — a perceptual color space designed for image processing and color manipulation, adopted by [CSS Color Module Level 4](https://www.w3.org/TR/css-color-4/#specifying-oklab-oklch).
+
+Since OKLab objects use the same `l`/`a`/`b` channel keys as CIE LAB, object input requires an `ok: true` marker (bare `{ l, a, b }` objects belong to the **lab** plugin). Strings are unambiguous and need no marker. The alpha channel lives in an `alpha` key (as in the **lab** plugin) because `a` is taken by the green–red axis. Colors outside the sRGB gamut are clipped channel-by-channel — the same strategy browsers use when rendering an out-of-gamut `oklab()` value on an sRGB screen.
+
+```js
+import { colord, extend } from "colord";
+import oklabPlugin from "colord/plugins/oklab";
+
+extend([oklabPlugin]);
+
+colord("oklab(0.628 0.2249 0.1258)").toHex(); // "#ff0000"
+colord({ l: 0.628, a: 0.2249, b: 0.1258, ok: true }).toHex(); // "#ff0000"
+
+colord("#ffffff").toOklab(); // { l: 1, a: 0, b: 0, alpha: 1, ok: true }
+colord("#ff6347").toOklabString(); // "oklab(0.6962 0.1652 0.1045)"
+```
+
+</details>
+
+<details>
+  <summary><b><code>oklch</code> (OKLCH color space)</b> <i>1.25 KB</i></summary>
+
+Adds support of [OKLCH](https://evilmartians.com/chronicles/oklch-in-css-why-quit-rgb-hsl) — the polar form of OKLab and the format modern design systems (e.g. Tailwind CSS) define their palettes in. Adopted by [CSS Color Module Level 4](https://www.w3.org/TR/css-color-4/#specifying-oklab-oklch).
+
+Since OKLCH objects use the same `l`/`c`/`h` channel keys as CIE LCH, object input requires an `ok: true` marker (bare `{ l, c, h }` objects belong to the **lch** plugin). Strings are unambiguous and need no marker. The alpha channel lives in the regular `a` key, same as the **lch** plugin. Colors outside the sRGB gamut are clipped channel-by-channel — the same strategy browsers use when rendering an out-of-gamut `oklch()` value on an sRGB screen.
+
+```js
+import { colord, extend } from "colord";
+import oklchPlugin from "colord/plugins/oklch";
+
+extend([oklchPlugin]);
+
+colord("oklch(0.5 0.2 240)").toHex(); // "#0069c7"
+colord({ l: 0.5431, c: 0.0927, h: 194.77, ok: true }).toHex(); // "#008080"
+
+colord("#008080").toOklch(); // { l: 0.5431, c: 0.0927, h: 194.77, a: 1, ok: true }
+colord("#008080").alpha(0.5).toOklchString(); // "oklch(0.5431 0.0927 194.77 / 0.5)"
 ```
 
 </details>

--- a/package.json
+++ b/package.json
@@ -90,6 +90,18 @@
       "require": "./plugins/names.js",
       "default": "./plugins/names.mjs"
     },
+    "./plugins/oklab": {
+      "types": "./plugins/oklab.d.ts",
+      "import": "./plugins/oklab.mjs",
+      "require": "./plugins/oklab.js",
+      "default": "./plugins/oklab.mjs"
+    },
+    "./plugins/oklch": {
+      "types": "./plugins/oklch.d.ts",
+      "import": "./plugins/oklch.mjs",
+      "require": "./plugins/oklch.js",
+      "default": "./plugins/oklch.mjs"
+    },
     "./plugins/xyz": {
       "types": "./plugins/xyz.d.ts",
       "import": "./plugins/xyz.mjs",
@@ -203,6 +215,14 @@
     },
     {
       "path": "dist/plugins/names.mjs",
+      "limit": "1.5 KB"
+    },
+    {
+      "path": "dist/plugins/oklab.mjs",
+      "limit": "1.5 KB"
+    },
+    {
+      "path": "dist/plugins/oklch.mjs",
       "limit": "1.5 KB"
     },
     {

--- a/src/colorModels/lab.ts
+++ b/src/colorModels/lab.ts
@@ -29,8 +29,9 @@ export const roundLaba = (laba: LabaColor): LabaColor => ({
   alpha: round(laba.alpha, ALPHA_PRECISION),
 });
 
-export const parseLaba = ({ l, a, b, alpha = 1 }: InputObject): RgbaColor | null => {
-  if (!isPresent(l) || !isPresent(a) || !isPresent(b)) return null;
+export const parseLaba = ({ l, a, b, alpha = 1, ok }: InputObject): RgbaColor | null => {
+  // Objects marked with `ok: true` are OKLab colors, not CIE LAB (see the oklab plugin)
+  if (ok || !isPresent(l) || !isPresent(a) || !isPresent(b)) return null;
 
   const laba = clampLaba({
     l: Number(l),

--- a/src/colorModels/lch.ts
+++ b/src/colorModels/lch.ts
@@ -22,8 +22,9 @@ export const roundLcha = (laba: LchaColor): LchaColor => ({
   a: round(laba.a, ALPHA_PRECISION),
 });
 
-export const parseLcha = ({ l, c, h, a = 1 }: InputObject): RgbaColor | null => {
-  if (!isPresent(l) || !isPresent(c) || !isPresent(h)) return null;
+export const parseLcha = ({ l, c, h, a = 1, ok }: InputObject): RgbaColor | null => {
+  // Objects marked with `ok: true` are OKLCH colors, not CIE LCH (see the oklch plugin)
+  if (ok || !isPresent(l) || !isPresent(c) || !isPresent(h)) return null;
 
   const lcha = clampLcha({
     l: Number(l),

--- a/src/colorModels/oklab.ts
+++ b/src/colorModels/oklab.ts
@@ -1,0 +1,108 @@
+import { RgbaColor, OklabaColor, InputObject } from "../types";
+import { ALPHA_PRECISION } from "../constants";
+import { clamp, isPresent, round } from "../helpers";
+import { clampRgba, linearizeRgbChannel, unlinearizeRgbChannel } from "./rgb";
+
+/**
+ * Clamps OKLab axis values as defined in CSS Color Level 4 specs.
+ * https://www.w3.org/TR/css-color-4/#specifying-oklab-oklch
+ */
+export const clampOklaba = (laba: OklabaColor): OklabaColor => ({
+  // Lightness is defined in [0, 1] (unlike CIE LAB's [0, 100])
+  l: clamp(laba.l),
+  // A and B axis values are signed (allow both positive and negative values)
+  // and theoretically unbounded (but in practice do not exceed ±0.4)
+  a: laba.a,
+  b: laba.b,
+  alpha: clamp(laba.alpha),
+  ok: true,
+});
+
+export const roundOklaba = (laba: OklabaColor): OklabaColor => ({
+  // OKLab scales are ~100 times smaller than CIE LAB's ([0, 1] vs [0, 100]),
+  // so the 2 decimal places used by the CIE models would be too coarse
+  l: round(laba.l, 4),
+  a: round(laba.a, 4),
+  b: round(laba.b, 4),
+  alpha: round(laba.alpha, ALPHA_PRECISION),
+  ok: true,
+});
+
+export const parseOklaba = ({ l, a, b, alpha = 1, ok }: InputObject): RgbaColor | null => {
+  // Bare { l, a, b } objects belong to the CIE LAB plugin;
+  // the `ok` marker is what distinguishes an OKLab object (see the oklab plugin docs)
+  if (ok !== true || !isPresent(l) || !isPresent(a) || !isPresent(b)) return null;
+
+  const laba = clampOklaba({
+    l: Number(l),
+    a: Number(a),
+    b: Number(b),
+    alpha: Number(alpha),
+    ok: true,
+  });
+
+  return oklabaToRgba(laba);
+};
+
+/**
+ * Performs linear RGB → OKLab color conversion. The math is ported from the
+ * CSS Color Module Level 4 Specification sample code, which recalculated
+ * Björn Ottosson's original matrices to 64-bit precision with a consistent
+ * D65 reference white (so pure white maps to exactly { l: 1, a: 0, b: 0 }).
+ * The linear-sRGB → LMS matrix below is the spec's XYZ→LMS × linear-sRGB→XYZ
+ * product, composed in double precision to skip the intermediate XYZ step.
+ * https://www.w3.org/TR/css-color-4/#color-conversion-code
+ * https://github.com/w3c/csswg-drafts/issues/6642#issuecomment-943521484
+ */
+export const rgbaToOklaba = (rgba: RgbaColor): OklabaColor => {
+  const red = linearizeRgbChannel(rgba.r);
+  const green = linearizeRgbChannel(rgba.g);
+  const blue = linearizeRgbChannel(rgba.b);
+
+  const l = Math.cbrt(
+    0.412221469470763 * red + 0.5363325372617348 * green + 0.0514459932675022 * blue
+  );
+  const m = Math.cbrt(
+    0.2119034958178252 * red + 0.6806995506452344 * green + 0.1073969535369406 * blue
+  );
+  const s = Math.cbrt(
+    0.0883024591900564 * red + 0.2817188391361215 * green + 0.6299787016738222 * blue
+  );
+
+  return {
+    l: 0.210454268309314 * l + 0.7936177747023054 * m - 0.0040720430116193 * s,
+    a: 1.9779985324311684 * l - 2.42859224204858 * m + 0.450593709617411 * s,
+    b: 0.0259040424655478 * l + 0.7827717124575296 * m - 0.8086757549230774 * s,
+    alpha: rgba.a,
+    ok: true,
+  };
+};
+
+/**
+ * Performs OKLab → linear RGB color conversion (the inverse of the matrices above,
+ * from the same CSS Color 4 sample code). Round-trips a color to the exact same
+ * byte values, unlike the lower-precision matrices in Ottosson's original post.
+ * https://www.w3.org/TR/css-color-4/#color-conversion-code
+ */
+export const oklabaToRgba = (laba: OklabaColor): RgbaColor => {
+  const l = laba.l + 0.3963377773761749 * laba.a + 0.2158037573099136 * laba.b;
+  const m = laba.l - 0.1055613458156586 * laba.a - 0.0638541728258133 * laba.b;
+  const s = laba.l - 0.0894841775298119 * laba.a - 1.2914855480194092 * laba.b;
+
+  const l3 = l * l * l;
+  const m3 = m * m * m;
+  const s3 = s * s * s;
+
+  return clampRgba({
+    r: unlinearizeRgbChannel(
+      4.0767416360759583 * l3 - 3.3077115392580616 * m3 + 0.2309699031821043 * s3
+    ),
+    g: unlinearizeRgbChannel(
+      -1.2684379732850317 * l3 + 2.6097573492876887 * m3 - 0.3413193760026573 * s3
+    ),
+    b: unlinearizeRgbChannel(
+      -0.0041960761386756 * l3 - 0.7034186179359363 * m3 + 1.7076146940746117 * s3
+    ),
+    a: laba.alpha,
+  });
+};

--- a/src/colorModels/oklabString.ts
+++ b/src/colorModels/oklabString.ts
@@ -1,0 +1,32 @@
+import { RgbaColor } from "../types";
+import { clampOklaba, oklabaToRgba, rgbaToOklaba, roundOklaba } from "./oklab";
+
+// The only valid OKLab syntax (modern space-separated form; no legacy comma form exists)
+// oklab() = oklab( [<percentage> | <number>]{3} [ / <alpha-value> ]? )
+// 100% equals 1 for lightness and 0.4 for both axes
+const oklabaMatcher = /^oklab\(\s*([+-]?(?:\d*\.\d+|\d+))(%)?\s+([+-]?(?:\d*\.\d+|\d+))(%)?\s+([+-]?(?:\d*\.\d+|\d+))(%)?\s*(?:\/\s*([+-]?(?:\d*\.\d+|\d+))(%)?\s*)?\)$/i;
+
+/**
+ * Parses a valid OKLab CSS color function/string
+ * https://www.w3.org/TR/css-color-4/#specifying-oklab-oklch
+ */
+export const parseOklabaString = (input: string): RgbaColor | null => {
+  const match = oklabaMatcher.exec(input);
+
+  if (!match) return null;
+
+  const laba = clampOklaba({
+    l: Number(match[1]) / (match[2] ? 100 : 1),
+    a: Number(match[3]) * (match[4] ? 0.004 : 1),
+    b: Number(match[5]) * (match[6] ? 0.004 : 1),
+    alpha: match[7] === undefined ? 1 : Number(match[7]) / (match[8] ? 100 : 1),
+    ok: true,
+  });
+
+  return oklabaToRgba(laba);
+};
+
+export const rgbaToOklabaString = (rgba: RgbaColor): string => {
+  const { l, a, b, alpha } = roundOklaba(rgbaToOklaba(rgba));
+  return alpha < 1 ? `oklab(${l} ${a} ${b} / ${alpha})` : `oklab(${l} ${a} ${b})`;
+};

--- a/src/colorModels/oklch.ts
+++ b/src/colorModels/oklch.ts
@@ -1,0 +1,80 @@
+import { RgbaColor, OklchaColor, InputObject } from "../types";
+import { ALPHA_PRECISION } from "../constants";
+import { clamp, clampHue, isPresent, round, roundHue } from "../helpers";
+import { oklabaToRgba, rgbaToOklaba } from "./oklab";
+
+/**
+ * Clamps OKLCH axis values as defined in CSS Color Level 4 specs.
+ * https://www.w3.org/TR/css-color-4/#specifying-oklab-oklch
+ */
+export const clampOklcha = (lcha: OklchaColor): OklchaColor => ({
+  l: clamp(lcha.l),
+  // Negative chroma is clamped to 0; it is theoretically unbounded above
+  // (but in practice does not exceed 0.4)
+  c: lcha.c < 0 ? 0 : lcha.c,
+  h: clampHue(lcha.h),
+  a: clamp(lcha.a),
+  ok: true,
+});
+
+export const roundOklcha = (lcha: OklchaColor): OklchaColor => ({
+  // See the note in `roundOklaba`: OKLab scales require finer rounding than CIE's
+  l: round(lcha.l, 4),
+  c: round(lcha.c, 4),
+  h: roundHue(lcha.h, 2),
+  a: round(lcha.a, ALPHA_PRECISION),
+  ok: true,
+});
+
+export const parseOklcha = ({ l, c, h, a = 1, ok }: InputObject): RgbaColor | null => {
+  // Bare { l, c, h } objects belong to the CIE LCH plugin;
+  // the `ok` marker is what distinguishes an OKLCH object (see the oklch plugin docs)
+  if (ok !== true || !isPresent(l) || !isPresent(c) || !isPresent(h)) return null;
+
+  const lcha = clampOklcha({
+    l: Number(l),
+    c: Number(c),
+    h: Number(h),
+    a: Number(a),
+    ok: true,
+  });
+
+  return oklchaToRgba(lcha);
+};
+
+/**
+ * Performs RGB → OKLab → OKLCH color conversion
+ * https://www.w3.org/TR/css-color-4/#color-conversion-code
+ */
+export const rgbaToOklcha = (rgba: RgbaColor): OklchaColor => {
+  const laba = rgbaToOklaba(rgba);
+
+  // Round axis values to get proper values for grayscale colors.
+  // OKLab axes are ~100 times smaller than CIE LAB's, hence 6 decimals instead of 3.
+  const a = round(laba.a, 6);
+  const b = round(laba.b, 6);
+
+  const hue = 180 * (Math.atan2(b, a) / Math.PI);
+
+  return {
+    l: laba.l,
+    c: Math.sqrt(a * a + b * b),
+    h: hue < 0 ? hue + 360 : hue,
+    a: laba.alpha,
+    ok: true,
+  };
+};
+
+/**
+ * Performs OKLCH → OKLab → RGB color conversion
+ * https://www.w3.org/TR/css-color-4/#color-conversion-code
+ */
+export const oklchaToRgba = (lcha: OklchaColor): RgbaColor => {
+  return oklabaToRgba({
+    l: lcha.l,
+    a: lcha.c * Math.cos((lcha.h * Math.PI) / 180),
+    b: lcha.c * Math.sin((lcha.h * Math.PI) / 180),
+    alpha: lcha.a,
+    ok: true,
+  });
+};

--- a/src/colorModels/oklchString.ts
+++ b/src/colorModels/oklchString.ts
@@ -1,0 +1,33 @@
+import { RgbaColor } from "../types";
+import { parseHue } from "../helpers";
+import { clampOklcha, oklchaToRgba, rgbaToOklcha, roundOklcha } from "./oklch";
+
+// The only valid OKLCH syntax (modern space-separated form; no legacy comma form exists)
+// oklch() = oklch( [<percentage> | <number>] [<percentage> | <number>] <hue> [ / <alpha-value> ]? )
+// 100% equals 1 for lightness and 0.4 for chroma
+const oklchaMatcher = /^oklch\(\s*([+-]?(?:\d*\.\d+|\d+))(%)?\s+([+-]?(?:\d*\.\d+|\d+))(%)?\s+([+-]?(?:\d*\.\d+|\d+))(deg|rad|grad|turn)?\s*(?:\/\s*([+-]?(?:\d*\.\d+|\d+))(%)?\s*)?\)$/i;
+
+/**
+ * Parses a valid OKLCH CSS color function/string
+ * https://www.w3.org/TR/css-color-4/#specifying-oklab-oklch
+ */
+export const parseOklchaString = (input: string): RgbaColor | null => {
+  const match = oklchaMatcher.exec(input);
+
+  if (!match) return null;
+
+  const lcha = clampOklcha({
+    l: Number(match[1]) / (match[2] ? 100 : 1),
+    c: Number(match[3]) * (match[4] ? 0.004 : 1),
+    h: parseHue(match[5], match[6]),
+    a: match[7] === undefined ? 1 : Number(match[7]) / (match[8] ? 100 : 1),
+    ok: true,
+  });
+
+  return oklchaToRgba(lcha);
+};
+
+export const rgbaToOklchaString = (rgba: RgbaColor): string => {
+  const { l, c, h, a } = roundOklcha(rgbaToOklcha(rgba));
+  return a < 1 ? `oklch(${l} ${c} ${h} / ${a})` : `oklch(${l} ${c} ${h})`;
+};

--- a/src/plugins/oklab.ts
+++ b/src/plugins/oklab.ts
@@ -1,0 +1,40 @@
+import { OklabaColor } from "../types";
+import { Plugin } from "../extend";
+import { parseOklaba, rgbaToOklaba, roundOklaba } from "../colorModels/oklab";
+import { parseOklabaString, rgbaToOklabaString } from "../colorModels/oklabString";
+
+declare module "../colord" {
+  interface Colord {
+    /**
+     * Converts a color to OKLab color space and returns an object.
+     * The object carries an `ok: true` marker that distinguishes it
+     * from a CIE LAB object (both use the same `l`/`a`/`b` channel keys).
+     * https://bottosson.github.io/posts/oklab/
+     */
+    toOklab(): OklabaColor;
+    /**
+     * Converts a color to OKLab color space and returns a string.
+     * https://developer.mozilla.org/en-US/docs/Web/CSS/color_value/oklab
+     */
+    toOklabString(): string;
+  }
+}
+
+/**
+ * A plugin adding support for OKLab color space.
+ * https://bottosson.github.io/posts/oklab/
+ */
+const oklabPlugin: Plugin = (ColordClass, parsers): void => {
+  ColordClass.prototype.toOklab = function () {
+    return roundOklaba(rgbaToOklaba(this.rgba));
+  };
+
+  ColordClass.prototype.toOklabString = function () {
+    return rgbaToOklabaString(this.rgba);
+  };
+
+  parsers.string.push([parseOklabaString, "oklab"]);
+  parsers.object.push([parseOklaba, "oklab"]);
+};
+
+export default oklabPlugin;

--- a/src/plugins/oklch.ts
+++ b/src/plugins/oklch.ts
@@ -1,0 +1,40 @@
+import { OklchaColor } from "../types";
+import { Plugin } from "../extend";
+import { parseOklcha, rgbaToOklcha, roundOklcha } from "../colorModels/oklch";
+import { parseOklchaString, rgbaToOklchaString } from "../colorModels/oklchString";
+
+declare module "../colord" {
+  interface Colord {
+    /**
+     * Converts a color to OKLCH (OKLab in polar form) color space and returns an object.
+     * The object carries an `ok: true` marker that distinguishes it
+     * from a CIE LCH object (both use the same `l`/`c`/`h` channel keys).
+     * https://evilmartians.com/chronicles/oklch-in-css-why-quit-rgb-hsl
+     */
+    toOklch(): OklchaColor;
+    /**
+     * Converts a color to OKLCH color space and returns a string.
+     * https://developer.mozilla.org/en-US/docs/Web/CSS/color_value/oklch
+     */
+    toOklchString(): string;
+  }
+}
+
+/**
+ * A plugin adding support for OKLCH color space.
+ * https://evilmartians.com/chronicles/oklch-in-css-why-quit-rgb-hsl
+ */
+const oklchPlugin: Plugin = (ColordClass, parsers): void => {
+  ColordClass.prototype.toOklch = function () {
+    return roundOklcha(rgbaToOklcha(this.rgba));
+  };
+
+  ColordClass.prototype.toOklchString = function () {
+    return rgbaToOklchaString(this.rgba);
+  };
+
+  parsers.string.push([parseOklchaString, "oklch"]);
+  parsers.object.push([parseOklcha, "oklch"]);
+};
+
+export default oklchPlugin;

--- a/src/types.ts
+++ b/src/types.ts
@@ -40,6 +40,22 @@ export interface LchColor {
   h: number;
 }
 
+export interface OklabColor {
+  l: number;
+  a: number;
+  b: number;
+  /** Distinguishes OKLab objects from CIE LAB objects, which share the same channel keys */
+  ok: true;
+}
+
+export interface OklchColor {
+  l: number;
+  c: number;
+  h: number;
+  /** Distinguishes OKLCH objects from CIE LCH objects, which share the same channel keys */
+  ok: true;
+}
+
 export interface CmykColor {
   c: number;
   m: number;
@@ -55,6 +71,8 @@ export type HwbaColor = WithAlpha<HwbColor>;
 export type XyzaColor = WithAlpha<XyzColor>; // Naming is the hardest part https://stackoverflow.com/a/2464027
 export type LabaColor = LabColor & { alpha: number };
 export type LchaColor = WithAlpha<LchColor>;
+export type OklabaColor = OklabColor & { alpha: number };
+export type OklchaColor = WithAlpha<OklchColor>;
 export type CmykaColor = WithAlpha<CmykColor>;
 
 export type ObjectColor =
@@ -72,6 +90,10 @@ export type ObjectColor =
   | LabaColor
   | LchColor
   | LchaColor
+  | OklabColor
+  | OklabaColor
+  | OklchColor
+  | OklchaColor
   | CmykColor
   | CmykaColor;
 
@@ -89,6 +111,8 @@ export type Format =
   | "xyz"
   | "lab"
   | "lch"
+  | "oklab"
+  | "oklch"
   | "cmyk";
 
 export type Input = string | InputObject;

--- a/tests/parse-complexity.test.ts
+++ b/tests/parse-complexity.test.ts
@@ -2,8 +2,10 @@ import { colord, extend } from "../src/";
 import cmykPlugin from "../src/plugins/cmyk";
 import hwbPlugin from "../src/plugins/hwb";
 import lchPlugin from "../src/plugins/lch";
+import oklabPlugin from "../src/plugins/oklab";
+import oklchPlugin from "../src/plugins/oklch";
 
-extend([cmykPlugin, hwbPlugin, lchPlugin]);
+extend([cmykPlugin, hwbPlugin, lchPlugin, oklabPlugin, oklchPlugin]);
 
 /**
  * Every CSS function matcher spells a number as `(?:\d*\.\d+|\d+)` instead of the
@@ -39,6 +41,8 @@ describe("Rejects oversized malformed colors in linear time", () => {
     ["hsl, alpha position", `hsl(1deg 2% 3% / ${digits}!`],
     ["hwb", `hwb(${digits}!`],
     ["lch", `lch(${digits}!`],
+    ["oklab", `oklab(${digits}!`],
+    ["oklch", `oklch(${digits}!`],
     ["device-cmyk", `device-cmyk(${digits}!`],
   ])(
     "%s",

--- a/tests/plugins.test.ts
+++ b/tests/plugins.test.ts
@@ -6,6 +6,8 @@ import hwbPlugin from "../src/plugins/hwb";
 import labPlugin from "../src/plugins/lab";
 import lchPlugin from "../src/plugins/lch";
 import minifyPlugin from "../src/plugins/minify";
+import oklabPlugin from "../src/plugins/oklab";
+import oklchPlugin from "../src/plugins/oklch";
 import mixPlugin from "../src/plugins/mix";
 import namesPlugin from "../src/plugins/names";
 import xyzPlugin from "../src/plugins/xyz";
@@ -493,5 +495,220 @@ describe("xyz", () => {
 
   it("Supported by `getFormat`", () => {
     expect(getFormat({ x: 50, y: 50, z: 50 })).toBe("xyz");
+  });
+});
+
+describe("oklab", () => {
+  extend([oklabPlugin]);
+
+  it("Parses OKLab color object", () => {
+    // Reference values are cross-checked against culori
+    // https://culorijs.org/color-spaces/#oklab
+    expect(colord({ l: 1, a: 0, b: 0, ok: true }).toHex()).toBe("#ffffff");
+    expect(colord({ l: 0, a: 0, b: 0, ok: true }).toHex()).toBe("#000000");
+    expect(colord({ l: 0.628, a: 0.2249, b: 0.1258, ok: true }).toHex()).toBe("#ff0000");
+    expect(colord({ l: 0.8664, a: -0.2339, b: 0.1795, ok: true }).toHex()).toBe("#00ff00");
+    expect(colord({ l: 0.7844, a: -0.0114, b: -0.0285, ok: true }).toHex()).toBe("#aabbcc");
+    expect(colord({ l: 0.2684, a: 0.0162, b: 0.0347, alpha: 0.5, ok: true }).toHex()).toBe(
+      "#33221180"
+    );
+  });
+
+  it("Treats objects without the `ok` marker as CIE LAB", () => {
+    expect(getFormat({ l: 0.628, a: 0.2249, b: 0.1258 })).toBe("lab");
+  });
+
+  it("Parses marked objects regardless of plugin registration order", () => {
+    // The lab plugin is registered before oklab in this suite;
+    // its parser must not swallow objects carrying the `ok` marker
+    expect(getFormat({ l: 0.628, a: 0.2249, b: 0.1258, ok: true })).toBe("oklab");
+    expect(colord({ l: 0.628, a: 0.2249, b: 0.1258, ok: true }).toHex()).toBe("#ff0000");
+  });
+
+  it("Parses OKLab color string", () => {
+    // https://www.w3.org/TR/css-color-4/#specifying-oklab-oklch
+    expect(colord("oklab(1 0 0)").toHex()).toBe("#ffffff");
+    expect(colord("oklab(0.628 0.2249 0.1258)").toHex()).toBe("#ff0000");
+    expect(colord("oklab(0.8664 -0.2339 0.1795)").toHex()).toBe("#00ff00");
+    // Percentage form: 100% = 1 for lightness, 100% = 0.4 for the axes
+    expect(colord("oklab(62.8% 56.225% 31.45%)").toHex()).toBe("#ff0000");
+    expect(colord("oklab(0.2684 0.0162 0.0347 / 0.5)").toHex()).toBe("#33221180");
+    expect(colord("oklab(0.2684 0.0162 0.0347 / 50%)").toHex()).toBe("#33221180");
+  });
+
+  it("Matches the web-platform-tests conformance values", () => {
+    // The reference pairs browsers are tested against
+    // https://github.com/web-platform-tests/wpt/tree/master/css/css-color (oklab-001, 004, 005)
+    expect(colord("oklab(51.975% -0.1403 0.10768)").toHex()).toBe("#008000");
+    expect(colord("oklab(50% 0.05 0)").toHex()).toBe("#7c5762"); // rgb(48.477% 34.29% 38.412%)
+    expect(colord("oklab(70% -0.1 0)").toHex()).toBe("#4bb3a1"); // rgb(29.264% 70.096% 63.017%)
+    expect(colord("#008000").toOklab()).toMatchObject({ l: 0.5198, a: -0.1403, b: 0.1077 });
+  });
+
+  it("Converts a color to OKLab object", () => {
+    expect(colord("#ffffff").toOklab()).toMatchObject({ l: 1, a: 0, b: 0, alpha: 1, ok: true });
+    expect(colord("#000000").toOklab()).toMatchObject({ l: 0, a: 0, b: 0, alpha: 1 });
+    expect(colord("#ff0000").toOklab()).toMatchObject({ l: 0.628, a: 0.2249, b: 0.1258 });
+    expect(colord("#00ff00").toOklab()).toMatchObject({ l: 0.8664, a: -0.2339, b: 0.1795 });
+    expect(colord("#0000ff").toOklab()).toMatchObject({ l: 0.452, a: -0.0325, b: -0.3115 });
+    expect(colord("#aabbcc").toOklab()).toMatchObject({ l: 0.7844, a: -0.0114, b: -0.0285 });
+    expect(colord("#33221180").toOklab()).toMatchObject({
+      l: 0.2684,
+      a: 0.0162,
+      b: 0.0347,
+      alpha: 0.5,
+    });
+  });
+
+  it("Converts a color to OKLab string (CSS functional notation)", () => {
+    expect(colord("#ffffff").toOklabString()).toBe("oklab(1 0 0)");
+    expect(colord("#ff0000").toOklabString()).toBe("oklab(0.628 0.2249 0.1258)");
+    expect(colord("#33221180").toOklabString()).toBe("oklab(0.2684 0.0162 0.0347 / 0.5)");
+  });
+
+  it("Round-trips through the object form with the CIE plugins loaded", () => {
+    expect(colord(colord("#d53987").toOklab()).toHex()).toBe("#d53987");
+  });
+
+  it("Clamps invalid channel values", () => {
+    expect(colord({ l: 1.5, a: 0, b: 0, ok: true }).toHex()).toBe("#ffffff");
+    expect(colord({ l: -1, a: 0, b: 0, ok: true }).toHex()).toBe("#000000");
+    expect(colord({ l: 1, a: 0, b: 0, alpha: 2, ok: true }).toHex()).toBe("#ffffff");
+  });
+
+  it("Ignores invalid input", () => {
+    expect(colord("oklab(1 0)").isValid()).toBe(false);
+    expect(colord("oklab(1 0 0 0)").isValid()).toBe(false);
+    // @ts-ignore
+    expect(colord({ l: 0.5, a: 0.1, ok: true }).isValid()).toBe(false);
+  });
+
+  it("Supported by `getFormat`", () => {
+    expect(getFormat("oklab(0.628 0.2249 0.1258)")).toBe("oklab");
+    expect(getFormat({ l: 0.628, a: 0.2249, b: 0.1258, ok: true })).toBe("oklab");
+  });
+});
+
+describe("oklch", () => {
+  extend([oklchPlugin]);
+
+  it("Parses OKLCH color object", () => {
+    // Reference values are cross-checked against culori
+    // https://culorijs.org/color-spaces/#oklch
+    expect(colord({ l: 1, c: 0, h: 0, ok: true }).toHex()).toBe("#ffffff");
+    expect(colord({ l: 0, c: 0, h: 0, ok: true }).toHex()).toBe("#000000");
+    expect(colord({ l: 0.628, c: 0.2577, h: 29.23, ok: true }).toHex()).toBe("#ff0000");
+    expect(colord({ l: 0.5, c: 0.2, h: 240, ok: true }).toHex()).toBe("#0069c7");
+    expect(colord({ l: 0.2684, c: 0.0383, h: 64.93, a: 0.5, ok: true }).toHex()).toBe(
+      "#33221180"
+    );
+  });
+
+  it("Treats objects without the `ok` marker as CIE LCH", () => {
+    expect(getFormat({ l: 0.5, c: 0.1, h: 20 })).toBe("lch");
+  });
+
+  it("Parses marked objects regardless of plugin registration order", () => {
+    // The lch plugin is registered before oklch in this suite;
+    // its parser must not swallow objects carrying the `ok` marker
+    expect(getFormat({ l: 0.628, c: 0.2577, h: 29.23, ok: true })).toBe("oklch");
+    expect(colord({ l: 0.628, c: 0.2577, h: 29.23, ok: true }).toHex()).toBe("#ff0000");
+  });
+
+  it("Parses OKLCH color string", () => {
+    // https://www.w3.org/TR/css-color-4/#specifying-oklab-oklch
+    expect(colord("oklch(1 0 0)").toHex()).toBe("#ffffff");
+    expect(colord("oklch(0.628 0.2577 29.23)").toHex()).toBe("#ff0000");
+    expect(colord("oklch(0.5 0.2 240)").toHex()).toBe("#0069c7");
+    // Percentage form: 100% = 1 for lightness, 100% = 0.4 for chroma
+    expect(colord("oklch(62.8% 64.425% 29.23)").toHex()).toBe("#ff0000");
+    expect(colord("oklch(0.2684 0.0383 64.93 / 0.5)").toHex()).toBe("#33221180");
+    expect(colord("oklch(0.2684 0.0383 64.93 / 50%)").toHex()).toBe("#33221180");
+  });
+
+  it("Matches the web-platform-tests conformance values", () => {
+    // The reference pairs browsers are tested against
+    // https://github.com/web-platform-tests/wpt/tree/master/css/css-color (oklch-001, 004, 005)
+    expect(colord("oklch(51.975% 0.17686 142.495)").toHex()).toBe("#008000");
+    expect(colord("oklch(50% 0.2 0)").toHex()).toBe("#b4065f"); // rgb(70.492% 2.351% 37.073%)
+    expect(colord("oklch(50% 0.2 270)").toHex()).toBe("#3b51d3"); // rgb(23.056% 31.73% 82.628%)
+  });
+
+  it("Serializes the CSS Color 4 specification examples", () => {
+    // https://www.w3.org/TR/css-color-4/#serializing-oklab-oklch
+    expect(colord("oklch(56.43% 0.0900 123.40)").toOklchString()).toBe("oklch(0.5643 0.09 123.4)");
+    expect(colord("oklch(53.85% 0.1725 320.67 / 70%)").toOklchString()).toBe(
+      "oklch(0.5385 0.1725 320.67 / 0.7)"
+    );
+  });
+
+  it("Supports all valid CSS angle units", () => {
+    // https://developer.mozilla.org/en-US/docs/Web/CSS/angle
+    const reference = colord("oklch(0.8 0.1 90)").toHex();
+    expect(colord("oklch(0.8 0.1 90deg)").toHex()).toBe(reference);
+    expect(colord("oklch(0.8 0.1 100grad)").toHex()).toBe(reference);
+    expect(colord("oklch(0.8 0.1 0.25turn)").toHex()).toBe(reference);
+    expect(colord("oklch(0.8 0.1 1.5708rad)").toHex()).toBe(reference);
+  });
+
+  it("Converts a color to OKLCH object", () => {
+    expect(colord("#ffffff").toOklch()).toMatchObject({ l: 1, c: 0, h: 0, a: 1, ok: true });
+    expect(colord("#000000").toOklch()).toMatchObject({ l: 0, c: 0, h: 0, a: 1 });
+    // The CSS Color 4 specification says "sRGB blue is oklch(0.452 0.313 264.1)"
+    // (rounded to their precision). https://www.w3.org/TR/css-color-4/#ok-lab
+    expect(colord("#0000ff").toOklch()).toMatchObject({ l: 0.452, c: 0.3132, h: 264.05 });
+    expect(colord("#808080").toOklch()).toMatchObject({ l: 0.5999, c: 0, h: 0 });
+    expect(colord("#ff0000").toOklch()).toMatchObject({ l: 0.628, c: 0.2577, h: 29.23 });
+    expect(colord("#00ffff").toOklch()).toMatchObject({ l: 0.9054, c: 0.1546, h: 194.77 });
+    expect(colord("#d53987").toOklch()).toMatchObject({ l: 0.5999, c: 0.2029, h: 354.63 });
+    expect(colord("#33221180").toOklch()).toMatchObject({
+      l: 0.2684,
+      c: 0.0383,
+      h: 64.93,
+      a: 0.5,
+    });
+  });
+
+  it("Converts a color to OKLCH string (CSS functional notation)", () => {
+    expect(colord("#ffffff").toOklchString()).toBe("oklch(1 0 0)");
+    expect(colord("#808080").toOklchString()).toBe("oklch(0.5999 0 0)");
+    expect(colord("#ff0000").toOklchString()).toBe("oklch(0.628 0.2577 29.23)");
+    expect(colord("#33221180").toOklchString()).toBe("oklch(0.2684 0.0383 64.93 / 0.5)");
+  });
+
+  it("Keeps the hue within [0, 360)", () => {
+    expect(colord({ l: 0.5, c: 0.2, h: 360, ok: true }).toOklch().h).toBe(0);
+    expect(colord({ l: 0.5, c: 0.2, h: -120, ok: true }).toHex()).toBe(
+      colord({ l: 0.5, c: 0.2, h: 240, ok: true }).toHex()
+    );
+  });
+
+  it("Clips out-of-sRGB-gamut colors the way browsers render them", () => {
+    // oklch(0.8 0.29 145) is a Display-P3 green; each sRGB channel is clamped independently
+    expect(colord("oklch(0.8 0.29 145)").toHex()).toBe("#00e900");
+    expect(colord("oklch(0.8 0.29 145)").isValid()).toBe(true);
+  });
+
+  it("Round-trips through the object form with the CIE plugins loaded", () => {
+    expect(colord(colord("#d53987").toOklch()).toHex()).toBe("#d53987");
+  });
+
+  it("Clamps invalid channel values", () => {
+    expect(colord({ l: 1.5, c: 0, h: 0, ok: true }).toHex()).toBe("#ffffff");
+    expect(colord({ l: 0.5, c: -0.1, h: 20, ok: true }).toHex()).toBe(
+      colord({ l: 0.5, c: 0, h: 20, ok: true }).toHex()
+    );
+  });
+
+  it("Ignores invalid input", () => {
+    expect(colord("oklch(1 0)").isValid()).toBe(false);
+    expect(colord("oklch(1 0 0 0)").isValid()).toBe(false);
+    // @ts-ignore
+    expect(colord({ l: 0.5, c: 0.1, ok: true }).isValid()).toBe(false);
+  });
+
+  it("Supported by `getFormat`", () => {
+    expect(getFormat("oklch(0.628 0.2577 29.23)")).toBe("oklch");
+    expect(getFormat({ l: 0.628, c: 0.2577, h: 29.23, ok: true })).toBe("oklch");
   });
 });


### PR DESCRIPTION
Adds two opt-in plugins — `oklab` and `oklch` — bringing OKLab/OKLCH support to colord. Closes #87.

## Why

OKLCH has become the standard perceptual color space of modern CSS (CSS Color 4, 100% browser support, Tailwind v4 defines its whole palette in it), and #87 is the most-requested colord feature. The plugins cover parsing, conversion, and serialization for the sRGB world.

## What changed

- **New plugins** `colord/plugins/oklab` (1.04 KB) and `colord/plugins/oklch` (1.25 KB), following the lab/lch plugin structure: `toOklab()` / `toOklabString()` / `toOklch()` / `toOklchString()`, string + object parsing, `getFormat` support.
- **String parsing** follows the CSS Color 4 grammar: modern space-separated syntax, numbers or percentages (`100%` = `1` for lightness, `0.4` for axes/chroma), all hue units, both alpha forms.
- **Object input requires an `ok: true` marker** (`{ l, a, b, ok: true }`), because bare `{ l, a, b }` / `{ l, c, h }` objects already belong to the CIE lab/lch plugins. Without a marker, parse results would depend on `extend()` order. Output objects carry the marker too, so they round-trip through `colord()` with any plugin combination.
- **`parseLaba` / `parseLcha` now reject `ok`-marked objects** — otherwise they would swallow OKLab/OKLCH objects whenever lab/lch registered first. Technically a behavior change, but the `ok` key had no meaning before this PR.
- **Conversion math is ported from the CSS Color 4 sample code** (the 64-bit matrices from w3c/csswg-drafts#6642, the ones browsers implement), with the sRGB→XYZ→LMS matrices composed into one at full precision. Agreement with colorjs.io is ~7e-16; byte round-trips are exact; pure white maps to exactly `{ l: 1, a: 0, b: 0 }`.
- Out-of-sRGB-gamut input (e.g. a Display-P3 `oklch()` value) is channel-clamped — the same result browsers render on an sRGB screen. Documented in the README plugin sections.

## How to review

**Start with** `src/colorModels/oklab.ts` — the matrices and the `ok` marker logic; everything else layers on it (`oklch.ts` is the polar form, `*String.ts` are the CSS parsers/serializers, plugins are standard prototype wiring).

**Needs real attention:** the two-line guards in `src/colorModels/lab.ts` and `lch.ts` (the only touch to existing behavior), and the regexes in `oklabString.ts` / `oklchString.ts` — they use the backtracking-safe number form and are covered by `parse-complexity.test.ts`.

**Safe to skim:** README sections, package.json `exports`/`size-limit` entries, and the test tables — fixture values are cross-checked against culori, colorjs.io, the CSS Color 4 spec examples ("sRGB blue is oklch(0.452 0.313 264.1)", the serialization examples), and the web-platform-tests conformance pairs (oklab-001…005, oklch-001…005).

**Verified:** `lint`, `check-types`, `test` (641 tests, 100% coverage on the new files), `size` (both plugins well under their 1.5 KB budgets; the core bundle is untouched at 1.72 KB). Additionally swept 20k random colors against colorjs.io (max deviation 7.2e-16) with exact byte round-trips.
