### PR TITLE
chore: prepare the 2.9.6 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ### 2.9.6
 
 - Fix: Rotate the unrounded hue so `rotate` and `harmonies` preserve the original color
+- Fix: Normalize HWB whiteness + blackness over 100% to gray ❤️ [@spokodev](https://github.com/spokodev)
 
 ### 2.9.5
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "colord",
-  "version": "2.9.5",
+  "version": "2.9.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "colord",
-      "version": "2.9.5",
+      "version": "2.9.6",
       "license": "MIT",
       "devDependencies": {
         "@size-limit/preset-small-lib": "^11.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "colord",
-  "version": "2.9.5",
+  "version": "2.9.6",
   "description": "👑 A tiny yet powerful tool for high-performance color manipulations and conversions",
   "keywords": [
     "color",


### PR DESCRIPTION
Bumps the version to 2.9.6 and completes the CHANGELOG entries for the two fixes that landed since 2.9.5.

## Why

The `2.9.6` CHANGELOG section already existed with the `harmonies` fix (#148), but the HWB fix (#138) had no entry. This adds it, with credit to the contributor, and bumps `package.json` / `package-lock.json`.

## What changed

- CHANGELOG: added the HWB entry, crediting [@spokodev](https://github.com/spokodev) for #138
- Version bumped `2.9.5` → `2.9.6` in `package.json` and `package-lock.json`

## Release notes for 2.9.6

- Fix: Rotate the unrounded hue so `rotate` and `harmonies` preserve the original color (#148)
- Fix: Normalize HWB whiteness + blackness over 100% to gray (#138)

## How to review

Three-line diff, nothing structural. The thing worth a second look is not in this diff but in what it ships: **#138 changes observable output.** `hwbaToRgba` previously computed a negative saturation when `w + b > 100` (`hwb(0 60% 60%)` gave `100 - (60 / 40) * 100 = -50`); it now returns the spec-correct achromatic gray `w / (w + b)`. Anyone whose snapshots captured the old out-of-range results will see different numbers.

2.9.5's entry carried an explanatory note for the same reason. I left one off here to keep the entries compact per the repo convention — say the word if you'd rather have it spelled out for users.

<details><summary>Verification</summary>

Full CI suite run locally, all green:

- `npm run lint` — clean
- `npm run check-types` — clean
- `npm run test` — 613 tests, 25 suites, 100% coverage
- `npm run size` — all bundles under budget; `index.mjs` 1.72 KB / 2 KB
- `npm run check-release` — packages as `colord@2.9.6`, 67 files, 36.3 kB tarball

Two budgets are getting tight: `plugins/hwb.mjs` is 868 B / 1 KB (the #138 fix added roughly 80 B) and `plugins/names.mjs` is 1.45 KB / 1.5 KB.
</details>

## Fine print

Patch release, so per the repo conventions: no git tag and no GitHub Release. `npm run release` has not been run.
