### PR TITLE
perf(hex): parse and serialize HEX without parseInt and toString

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 2.9.7
+
+- Parse and serialize HEX colors without `parseInt` and `Number#toString`, making HEX input ~2x and HEX output ~2.7x faster
+
 ### 2.9.6
 
 - Fix: Rotate the unrounded hue so `rotate` and `harmonies` preserve the original color

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
 
 ## Features
 
-- 📦 **Small**: Just **1.7 KB** brotlied ([4x+ lighter](#benchmarks) than **color**)
+- 📦 **Small**: Just **1.8 KB** brotlied ([4x+ lighter](#benchmarks) than **color**)
 - 🚀 **Fast**: [4x+ faster](#benchmarks) than **color**
 - 😍 **Simple**: Chainable API and familiar patterns
 - 💪 **Immutable**: No need to worry about data mutations
@@ -42,7 +42,7 @@
 
 | Library                       | <nobr>Operations/sec</nobr>   | Size<br /> (minified) | Size<br /> (brotlied) | Type declarations                                                                                        |
 | ----------------------------- | ----------------------------- | --------------------- | --------------------- | -------------------------------------------------------------------------------------------------------- |
-| <nobr><b>colord 👑</b></nobr> | <nobr><b>3,524,989</b></nobr> | <b>5.71 kB</b>        | <b>1.71 kB</b>        | [![](https://badgen.net/npm/types/colord?color=6ead0a&label=)](https://npmjs.com/package/colord)         |
+| <nobr><b>colord 👑</b></nobr> | <nobr><b>3,524,989</b></nobr> | <b>5.81 kB</b>        | <b>1.80 kB</b>        | [![](https://badgen.net/npm/types/colord?color=6ead0a&label=)](https://npmjs.com/package/colord)         |
 | color                         | 744,263                       | 24 kB                 | 7.52 kB               | [![](https://badgen.net/npm/types/color?color=6ead0a&label=)](https://npmjs.com/package/color)           |
 | tinycolor2                    | 971,312                       | 15.23 kB              | 4.67 kB               | [![](https://badgen.net/npm/types/tinycolor2?color=e6591d&label=)](https://npmjs.com/package/tinycolor2) |
 | ac-colors                     | 660,722                       | 10.18 kB              | 2.96 kB               | [![](https://badgen.net/npm/types/ac-colors?color=red&label=)](https://npmjs.com/package/ac-colors)      |

--- a/src/colorModels/hex.ts
+++ b/src/colorModels/hex.ts
@@ -1,43 +1,74 @@
 import { RgbaColor } from "../types";
-import { round } from "../helpers";
+import { clamp, round } from "../helpers";
 import { roundRgba } from "./rgb";
 
 const hexMatcher = /^#([0-9a-f]{3,8})$/i;
 
+/**
+ * Reads the value of a single Hex digit from its char code.
+ *
+ * `parseInt` is the obvious tool, but it only takes a string, so every channel
+ * costs a substring allocation plus a generic radix parse — together the bulk of
+ * the time spent parsing a Hex color. ASCII makes the same value reachable with
+ * two integer ops: the low nibble of "0"-"9" (0x30-0x39) is already the digit,
+ * and "A"-"F" / "a"-"f" (0x41+ / 0x61+) are the only inputs with bit 6 set,
+ * which is exactly the +9 that turns their low nibble into 10-15.
+ */
+const digitAt = (hex: string, index: number): number => {
+  const code = hex.charCodeAt(index);
+  return (code & 0xf) + 9 * (code >> 6);
+};
+
+/** Reads the two Hex digits starting at `index` as a single byte. */
+const byteAt = (hex: string, index: number): number =>
+  (digitAt(hex, index) << 4) | digitAt(hex, index + 1);
+
 /** Parses any valid Hex3, Hex4, Hex6 or Hex8 string and converts it to an RGBA object */
 export const parseHex = (hex: string): RgbaColor | null => {
-  const hexMatch = hexMatcher.exec(hex);
+  // `test` over `exec`: the capture group is never read (the digits are addressed
+  // by index below), and skipping it saves allocating a match object per call.
+  if (!hexMatcher.test(hex)) return null;
 
-  if (!hexMatch) return null;
+  const { length } = hex;
 
-  hex = hexMatch[1];
-
-  if (hex.length <= 4) {
+  // Hex3 and Hex4 (leading "#" included in the length): every digit stands for
+  // a whole byte, which is the digit repeated — the same as multiplying by 17.
+  if (length <= 5) {
     return {
-      r: parseInt(hex[0] + hex[0], 16),
-      g: parseInt(hex[1] + hex[1], 16),
-      b: parseInt(hex[2] + hex[2], 16),
-      a: hex.length === 4 ? round(parseInt(hex[3] + hex[3], 16) / 255, 2) : 1,
+      r: digitAt(hex, 1) * 17,
+      g: digitAt(hex, 2) * 17,
+      b: digitAt(hex, 3) * 17,
+      a: length === 5 ? round((digitAt(hex, 4) * 17) / 255, 2) : 1,
     };
   }
 
-  if (hex.length === 6 || hex.length === 8) {
+  if (length === 7 || length === 9) {
     return {
-      r: parseInt(hex.substr(0, 2), 16),
-      g: parseInt(hex.substr(2, 2), 16),
-      b: parseInt(hex.substr(4, 2), 16),
-      a: hex.length === 8 ? round(parseInt(hex.substr(6, 2), 16) / 255, 2) : 1,
+      r: byteAt(hex, 1),
+      g: byteAt(hex, 3),
+      b: byteAt(hex, 5),
+      a: length === 9 ? round(byteAt(hex, 7) / 255, 2) : 1,
     };
   }
 
+  // The matcher also admits 5 and 7 digits, which no Hex notation uses
   return null;
 };
 
-/** Formats any decimal number (e.g. 128) as a hexadecimal string (e.g. "08") */
-const format = (number: number): string => {
-  const hex = number.toString(16);
-  return hex.length < 2 ? "0" + hex : hex;
-};
+/**
+ * Every byte a channel can hold, as a padded hexadecimal string.
+ *
+ * `Number#toString(16)` runs a generic radix conversion and then needs a length
+ * check to pad "0"-"f" back to two digits. There are only 256 possible answers,
+ * so precomputing them is both faster and shorter at the call site.
+ */
+const hexBytes: string[] = [];
+for (let byte = 0; byte < 256; byte++) {
+  hexBytes.push((byte < 16 ? "0" : "") + byte.toString(16));
+}
+
+/** Formats an already rounded channel value (e.g. 128) as a hexadecimal byte (e.g. "80") */
+const format = (byte: number): string => hexBytes[clamp(byte, 0, 255)];
 
 /** Converts RGBA object to Hex6 or (if it has alpha channel) Hex8 string */
 export const rgbaToHex = (rgba: RgbaColor): string => {

--- a/tests/colord.test.ts
+++ b/tests/colord.test.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 import { colord, random, getFormat, Colord, AnyColor } from "../src/";
 import { fixtures, lime, saturationLevels } from "./fixtures";
-import { clampHue, roundHue } from "../src/helpers";
+import { clampHue, round, roundHue } from "../src/helpers";
 
 it("Converts between HEX, RGB, HSL and HSV color models properly", () => {
   for (const fixture of fixtures) {
@@ -132,6 +132,53 @@ it("Supports HEX4 and HEX8 color models", () => {
   expect(colord({ r: 255, g: 255, b: 255, a: 1 }).toHex()).toBe("#ffffff");
   expect(colord({ r: 170, g: 170, b: 170, a: 0.5 }).toHex()).toBe("#aaaaaa80");
   expect(colord({ r: 128, g: 128, b: 128, a: 0 }).toHex()).toBe("#80808000");
+});
+
+it("Parses and serializes every HEX digit exactly", () => {
+  // Every byte survives a HEX6/HEX8 round trip, in both digit cases.
+  for (let byte = 0; byte < 256; byte++) {
+    const digits = byte.toString(16).padStart(2, "0");
+    const hex6 = `#${digits}${digits}${digits}`;
+    expect(colord(hex6).toRgb()).toMatchObject({ r: byte, g: byte, b: byte, a: 1 });
+    expect(colord(hex6.toUpperCase()).toRgb()).toMatchObject({ r: byte, g: byte, b: byte, a: 1 });
+    expect(colord({ r: byte, g: byte, b: byte, a: 1 }).toHex()).toBe(hex6);
+    expect(colord(`${hex6}${digits}`).toRgb()).toMatchObject({
+      r: byte,
+      g: byte,
+      b: byte,
+      a: round(byte / 255, 2),
+    });
+  }
+
+  // Every nibble is duplicated into a full byte by the HEX3/HEX4 shorthand.
+  for (let nibble = 0; nibble < 16; nibble++) {
+    const digit = nibble.toString(16);
+    const byte = nibble * 17;
+    expect(colord(`#${digit}${digit}${digit}`).toRgb()).toMatchObject({
+      r: byte,
+      g: byte,
+      b: byte,
+      a: 1,
+    });
+    expect(colord(`#000${digit}`).toRgb()).toMatchObject({
+      r: 0,
+      g: 0,
+      b: 0,
+      a: round(byte / 255, 2),
+    });
+  }
+
+  // A HEX string with an unsupported digit count is not a color.
+  expect(colord("#1").isValid()).toBe(false);
+  expect(colord("#12").isValid()).toBe(false);
+  expect(colord("#12345").isValid()).toBe(false);
+  expect(colord("#1234567").isValid()).toBe(false);
+  expect(colord("#123456789").isValid()).toBe(false);
+  expect(colord("#").isValid()).toBe(false);
+  // Only HEX digits are accepted.
+  expect(colord("#12345g").isValid()).toBe(false);
+  expect(colord("#-12345").isValid()).toBe(false);
+  expect(colord("# 12345").isValid()).toBe(false);
 });
 
 it("Ignores a case and extra whitespace", () => {


### PR DESCRIPTION
## Why

HEX is the format most callers hand us, and it turns out almost none of the time spent on `colord('#808080').toHsl()` went to color math. Profiling the pieces on the shipped `dist` build:

| step | before |
|---|---|
| `parseHex('#808080')` | 73 ns |
| `rgbaToHsla` (the RGB → HSV → HSL detour) | 5.7 ns |
| `roundHsla` | ~4 ns |

The conversion pipeline is essentially free — V8 elides the intermediate HSV object, so the two-stage form costs nothing measurable and is not worth touching. The parse is 85% of the work, and it is all string handling: `parseInt(hex.substr(...), 16)` allocates a substring per channel and then runs a generic radix parse (~44 ns of the 73), while `exec` allocates a match object whose capture group was never read (~6 ns).

The same pattern holds on the way out. `rgbaToHex` was the single most expensive step in `colord('#808080').lighten(0.2).toHex()`.

## What changed

Both fixes are in `src/colorModels/hex.ts`.

**Parsing.** Read the digits from their char codes instead of slicing strings. The low nibble of `0`-`9` (0x30-0x39) is already the digit's value, and `A`-`F` / `a`-`f` (0x41+ / 0x61+) are the only inputs with bit 6 set, which is exactly the +9 their low nibble needs — so two integer ops replace the substring allocation and the radix parse. `exec` becomes `test` for the same reason: nothing reads the capture group. Hex3/Hex4 expand a nibble into a byte by multiplying by 17 rather than concatenating the digit with itself.

**Serialization.** `Number#toString(16)` runs that same generic radix conversion and then needs a length check to pad `0`-`f` back to two digits. A channel has only 256 possible answers, so they are precomputed at load time and looked up.

The matcher itself is untouched — `{3,8}` is a bounded quantifier with no backtracking risk, so `tests/parse-complexity.test.ts` needed no new case.

## Results

Shipped `dist` builds, best of 9 runs of 1M iterations each, each case in its own process (sharing one process makes the call sites megamorphic and the numbers drift by up to 2x):

| | before | after |
|---|---|---|
| `colord('#808080')` | 85 ns | **29 ns** |
| `→ .toHsl()` | 103 ns | **40 ns** |
| `→ .toHex()` | 120 ns | **44 ns** |
| `→ .lighten(0.2).toHex()` | 179 ns | **121 ns** |
| `colord('#8080807f').toHex()` | 155 ns | **60 ns** |

`npm run benchmark` reports 6.32M → 10.28M ops/sec.

## Cost

The core bundle goes from 1.72 kB to 1.80 kB brotlied, against the 2 kB budget. Minified output barely moves (5799 → 5807 bytes) — the lookup-table loop replaces the `format` helper — but it compresses worse, which is where the 84 bytes come from. No plugin bundle changed.

## Notes for review

- **Behavior is unchanged.** Beyond the suite, I diffed the old and new builds across 147,477 assertions: every byte through Hex6/Hex8 in both letter cases, every nibble through Hex3/Hex4, all 1001 alpha values, malformed digit counts (1/2/5/7/9), non-hex characters, surrounding whitespace, and out-of-range / NaN / Infinity channels. No divergence.
- **One deliberate difference:** out-of-range channels are now clamped. They can't currently reach `rgbaToHex` (every parser clamps), but an unclamped lookup would return `undefined` and produce `#undefined…`, which is a worse failure mode than the malformed-but-stringy output `toString(16)` used to give.
- **Alpha rounding is preserved on purpose.** `rgbaToHex` still runs `roundRgba` before formatting, so alpha is rounded to 3 digits and only then scaled to a byte. Dropping that pre-rounding would look like a simplification but changes output for values landing on a half-byte boundary (`a = 7.5/255` serializes as `07` today, `08` without it).
- **New test** `Parses and serializes every HEX digit exactly` pins the behavior above. It was written before the refactor and verified to pass against the old implementation, so it characterizes rather than merely confirms. `hex.ts` stays at 100% coverage on all four metrics.
- **README `Operations/sec` is left stale** and now understates us. Refreshing it honestly means re-measuring every row on one machine, and on an M4 Max the competitors gained more than we did (`color` 744K → 2.70M vs our 3.52M → 10.28M), which would turn the "4x+ faster than color" claim into 3.8x. That's an editorial call, so I only updated the size figures (1.7 → 1.8 kB, in the feature list and the table).
- **CHANGELOG is filed under `2.9.7`** as the natural next patch — retitle if a different version is planned.

## Checks

`npm test` (98 passed, 100% on `hex.ts`), `npm run check-types`, `eslint` on the changed files, `prettier --check` on `src` and `tests`, and `size-limit` all pass. `npm run lint` fails in a git worktree for an unrelated reason: eslint 7 finds `eslint-plugin-prettier` in both the worktree and the parent `node_modules` and refuses to pick one. It passes with `--resolve-plugins-relative-to .`, and CI doesn't use a worktree.
