### PR TITLE
ci: run the benchmark in GitHub Actions

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -22,10 +22,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Use Node.js 22
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 22.x
           cache: npm

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,38 @@
+name: Benchmark
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+  workflow_dispatch:
+
+# Perf numbers are only worth having one run at a time per branch.
+concurrency:
+  group: benchmark-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  benchmark:
+    # Both the runner image and the Node major are pinned on purpose. The regression
+    # check watches how much faster colord is than its rivals rather than raw ops/sec,
+    # because absolute numbers swing ±10-30% between runs on shared runners. That ratio
+    # is far steadier, but it still drifts with hardware and V8 version, so the floors
+    # in tests/benchmark.ts are only meaningful against a fixed environment.
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Use Node.js 22
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22.x
+          cache: npm
+
+      # `npm ci` rather than `npm install`: the rival libraries are the denominator of
+      # every measurement, so they have to come from the lockfile.
+      - run: npm ci
+
+      - name: Run benchmark
+        run: npm run benchmark

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,10 +21,12 @@ That reach sets the priorities for every change:
 - **Test single case:** `npx jest tests/plugins.test.ts -t "lab"`
 - **Bundle size check:** `npm run size` (runs a full build first, then `size-limit`)
 - **Build:** `npm run build` (rollup → `dist/`)
-- **Benchmark:** `npm run benchmark` (compares against tinycolor2, chroma-js, etc.)
+- **Benchmark:** `npm run benchmark` (compares against tinycolor2, chroma-js, etc.; exits non-zero on a perf regression)
 - **Release dry run:** `npm run check-release`
 
 CI (`.github/workflows/node.yml`) runs `lint`, `check-types`, `test`, and `size` on Node 18/20/22. Run all four before declaring work done.
+
+A separate workflow (`.github/workflows/benchmark.yml`) runs `benchmark` on a pinned runner. It is both the regression check and the source of the numbers in README's benchmark table — copy them from the job summary rather than from a local run, since ops/sec are machine-specific. See the `MIN_SPEEDUP` comment in `tests/benchmark.ts` for why the check watches ratios instead of absolute numbers, and when to move the floors.
 
 ## Key constraint: bundle size
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@
 | ac-colors                    | 1,173,725                     | 10.18 kB              | 2.96 kB               | [![](https://badgen.net/npm/types/ac-colors?color=red&label=)](https://npmjs.com/package/ac-colors)      |
 | chroma-js                    | 1,200,753                     | 42.47 kB              | 14.89 kB              | [![](https://badgen.net/npm/types/chroma-js?color=e6591d&label=)](https://npmjs.com/package/chroma-js)   |
 
-The performance results come from the [Benchmark workflow](https://github.com/omgovich/colord/actions/workflows/benchmark.yml), which runs `npm run benchmark` on a pinned `ubuntu-24.04` runner under Node 22 — the numbers above are the "Parse HEX and convert to HSLA object/array" suite. Ops/sec are hardware-specific, so treat the ratios rather than the absolute values as the takeaway. See [tests/benchmark.ts](https://github.com/omgovich/colord/blob/master/tests/benchmark.ts). Bundle sizes come from [size-limit](https://github.com/ai/size-limit), importing each library's main export so unused code is tree-shaken away, the same way `npm run size` measures colord.
+Measured by the [Benchmark workflow](https://github.com/omgovich/colord/actions/workflows/benchmark.yml) on a standard GitHub-hosted runner (`ubuntu-24.04`, 4 vCPU, Node 22). Ops/sec depend on the machine, so read the ratios rather than the absolute numbers. See [tests/benchmark.ts](https://github.com/omgovich/colord/blob/master/tests/benchmark.ts). Bundle sizes come from [size-limit](https://github.com/ai/size-limit), importing each library's main export so unused code is tree-shaken away, the same way `npm run size` measures colord.
 
 <div><img src="assets/divider.png" width="838" alt="---" /></div>
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
 ## Features
 
 - 📦 **Small**: Just **1.7 KB** brotlied ([4x+ lighter](#benchmarks) than **color**)
-- 🚀 **Fast**: [4x+ faster](#benchmarks) than **color**
+- 🚀 **Fast**: [4x faster](#benchmarks) than **color**
 - 😍 **Simple**: Chainable API and familiar patterns
 - 💪 **Immutable**: No need to worry about data mutations
 - 🛡 **Bulletproof**: Written in strict TypeScript and has 100% test coverage
@@ -40,15 +40,15 @@
 
 ## Benchmarks
 
-| Library                       | <nobr>Operations/sec</nobr>   | Size<br /> (minified) | Size<br /> (brotlied) | Type declarations                                                                                        |
-| ----------------------------- | ----------------------------- | --------------------- | --------------------- | -------------------------------------------------------------------------------------------------------- |
-| <nobr><b>colord 👑</b></nobr> | <nobr><b>3,524,989</b></nobr> | <b>5.71 kB</b>        | <b>1.71 kB</b>        | [![](https://badgen.net/npm/types/colord?color=6ead0a&label=)](https://npmjs.com/package/colord)         |
-| color                         | 744,263                       | 24 kB                 | 7.52 kB               | [![](https://badgen.net/npm/types/color?color=6ead0a&label=)](https://npmjs.com/package/color)           |
-| tinycolor2                    | 971,312                       | 15.23 kB              | 4.67 kB               | [![](https://badgen.net/npm/types/tinycolor2?color=e6591d&label=)](https://npmjs.com/package/tinycolor2) |
-| ac-colors                     | 660,722                       | 10.18 kB              | 2.96 kB               | [![](https://badgen.net/npm/types/ac-colors?color=red&label=)](https://npmjs.com/package/ac-colors)      |
-| chroma-js                     | 962,967                       | 42.47 kB              | 14.89 kB              | [![](https://badgen.net/npm/types/chroma-js?color=e6591d&label=)](https://npmjs.com/package/chroma-js)   |
+| Library                      | <nobr>Operations/sec</nobr>   | Size<br /> (minified) | Size<br /> (brotlied) | Type declarations                                                                                        |
+| ---------------------------- | ----------------------------- | --------------------- | --------------------- | -------------------------------------------------------------------------------------------------------- |
+| <nobr><b>colord 👑</b></nobr> | <nobr><b>4,168,820</b></nobr> | <b>5.71 kB</b>        | <b>1.71 kB</b>        | [![](https://badgen.net/npm/types/colord?color=6ead0a&label=)](https://npmjs.com/package/colord)         |
+| color                        | 1,087,346                     | 24 kB                 | 7.52 kB               | [![](https://badgen.net/npm/types/color?color=6ead0a&label=)](https://npmjs.com/package/color)           |
+| tinycolor2                   | 1,481,881                     | 15.23 kB              | 4.67 kB               | [![](https://badgen.net/npm/types/tinycolor2?color=e6591d&label=)](https://npmjs.com/package/tinycolor2) |
+| ac-colors                    | 1,173,725                     | 10.18 kB              | 2.96 kB               | [![](https://badgen.net/npm/types/ac-colors?color=red&label=)](https://npmjs.com/package/ac-colors)      |
+| chroma-js                    | 1,200,753                     | 42.47 kB              | 14.89 kB              | [![](https://badgen.net/npm/types/chroma-js?color=e6591d&label=)](https://npmjs.com/package/chroma-js)   |
 
-The performance results were generated on an MBP 2019, 2,6 GHz Intel Core i7 by running `npm run benchmark` in the library folder. See [tests/benchmark.ts](https://github.com/omgovich/colord/blob/master/tests/benchmark.ts). Bundle sizes come from [size-limit](https://github.com/ai/size-limit), importing each library's main export so unused code is tree-shaken away, the same way `npm run size` measures colord.
+The performance results come from the [Benchmark workflow](https://github.com/omgovich/colord/actions/workflows/benchmark.yml), which runs `npm run benchmark` on a pinned `ubuntu-24.04` runner under Node 22 — the numbers above are the "Parse HEX and convert to HSLA object/array" suite. Ops/sec are hardware-specific, so treat the ratios rather than the absolute values as the takeaway. See [tests/benchmark.ts](https://github.com/omgovich/colord/blob/master/tests/benchmark.ts). Bundle sizes come from [size-limit](https://github.com/ai/size-limit), importing each library's main export so unused code is tree-shaken away, the same way `npm run size` measures colord.
 
 <div><img src="assets/divider.png" width="838" alt="---" /></div>
 

--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
     "size": "npm run build && size-limit",
     "check-types": "tsc --noEmit true",
     "test": "jest tests --coverage",
-    "benchmark": "tsc --outDir bench --skipLibCheck --esModuleInterop ./tests/benchmark.ts && node ./bench/tests/benchmark.js && rm -rf ./bench",
+    "benchmark": "tsc --outDir bench --skipLibCheck --esModuleInterop ./tests/benchmark.ts && node ./bench/tests/benchmark.js; code=$?; rm -rf ./bench; exit $code",
     "build": "rm -rf ./dist/* && rollup --config",
     "release": "npm run build && cp *.json dist && cp *.md dist && npm publish ./dist",
     "check-release": "npm run release -- --dry-run"

--- a/tests/benchmark.ts
+++ b/tests/benchmark.ts
@@ -23,9 +23,9 @@ import AcColor from "ac-colors";
  * regression, not to police single-digit percentages.
  */
 const MIN_SPEEDUP: Record<string, number> = {
-  "Parse HEX and convert to HSLA object/array": 1.55,
-  "Lighten, saturate, set alpha and convert to RGBA object": 1.4,
-  "Parse RGBA object and convert to HEX string": 1.3,
+  "Parse HEX and convert to HSLA object/array": 2.2,
+  "Lighten, saturate, set alpha and convert to RGBA object": 2.0,
+  "Parse RGBA object and convert to HEX string": 1.7,
 };
 
 const suites = [

--- a/tests/benchmark.ts
+++ b/tests/benchmark.ts
@@ -1,5 +1,7 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 import b from "benny";
+import { Summary } from "benny/lib/internal/common-types";
+import { appendFileSync } from "fs";
 import { colord } from "../src";
 // @ts-ignore
 import tinycolor2 from "tinycolor2";
@@ -10,33 +12,186 @@ import chroma from "chroma-js";
 // @ts-ignore
 import AcColor from "ac-colors";
 
-b.suite(
-  "Parse HEX and convert to HSLA object/array",
+/**
+ * How much faster colord must stay than its fastest rival in each suite.
+ *
+ * Absolute ops/sec are useless as a baseline on shared CI runners (±10-30% between
+ * runs), so we watch the ratio instead: every library is measured on the same machine
+ * in the same run, which cancels most of the noise out. The ratio still drifts with
+ * hardware and V8 version, so these floors are calibrated on the pinned runner from
+ * .github/workflows/benchmark.yml with generous headroom — they exist to catch a real
+ * regression, not to police single-digit percentages.
+ */
+const MIN_SPEEDUP: Record<string, number> = {
+  "Parse HEX and convert to HSLA object/array": 1.55,
+  "Lighten, saturate, set alpha and convert to RGBA object": 1.4,
+  "Parse RGBA object and convert to HEX string": 1.3,
+};
 
-  b.add("colord", () => {
-    colord("#808080").toHsl();
-  }),
+const suites = [
+  () =>
+    b.suite(
+      "Parse HEX and convert to HSLA object/array",
 
-  b.add("color", () => {
-    // @ts-ignore
-    color("#808080").hsl().object();
-  }),
+      b.add("colord", () => {
+        colord("#808080").toHsl();
+      }),
 
-  b.add("tinycolor2", () => {
-    // @ts-ignore
-    tinycolor2("#808080").toHsl();
-  }),
+      b.add("color", () => {
+        // @ts-ignore
+        color("#808080").hsl().object();
+      }),
 
-  b.add("ac-colors", () => {
-    // @ts-ignore
-    new AcColor({ color: "#808080", type: "hex" }).hsl;
-  }),
+      b.add("tinycolor2", () => {
+        // @ts-ignore
+        tinycolor2("#808080").toHsl();
+      }),
 
-  b.add("chroma-js", () => {
-    // @ts-ignore
-    chroma("#808080").hsl();
-  }),
+      b.add("ac-colors", () => {
+        // @ts-ignore
+        new AcColor({ color: "#808080", type: "hex" }).hsl;
+      }),
 
-  b.cycle(),
-  b.complete()
-);
+      b.add("chroma-js", () => {
+        // @ts-ignore
+        chroma("#808080").hsl();
+      }),
+
+      b.cycle(),
+      b.complete()
+    ),
+
+  // ac-colors is a pure converter — it ships no manipulation methods at all, so it
+  // cannot take part in this suite.
+  // The libraries disagree on what the arguments mean (tinycolor2 takes percents,
+  // chroma-js brightens in Lab), so the outputs differ. That is fine here: the suite
+  // exists to give colord's manipulation math a stable denominator to be measured
+  // against, not to claim the operations are equivalent.
+  () =>
+    b.suite(
+      "Lighten, saturate, set alpha and convert to RGBA object",
+
+      b.add("colord", () => {
+        colord("#808080").lighten(0.1).saturate(0.1).alpha(0.5).toRgb();
+      }),
+
+      b.add("color", () => {
+        // @ts-ignore
+        color("#808080").lighten(0.1).saturate(0.1).alpha(0.5).rgb().object();
+      }),
+
+      b.add("tinycolor2", () => {
+        // @ts-ignore
+        tinycolor2("#808080").lighten(10).saturate(10).setAlpha(0.5).toRgb();
+      }),
+
+      b.add("chroma-js", () => {
+        // @ts-ignore
+        chroma("#808080").brighten(0.1).saturate(0.1).alpha(0.5).rgb();
+      }),
+
+      b.cycle(),
+      b.complete()
+    ),
+
+  () =>
+    b.suite(
+      "Parse RGBA object and convert to HEX string",
+
+      b.add("colord", () => {
+        colord({ r: 128, g: 128, b: 128 }).toHex();
+      }),
+
+      b.add("color", () => {
+        // @ts-ignore
+        color({ r: 128, g: 128, b: 128 }).hex();
+      }),
+
+      b.add("tinycolor2", () => {
+        // @ts-ignore
+        tinycolor2({ r: 128, g: 128, b: 128 }).toHexString();
+      }),
+
+      b.add("ac-colors", () => {
+        // @ts-ignore
+        new AcColor({ color: [128, 128, 128], type: "rgb" }).hex;
+      }),
+
+      b.add("chroma-js", () => {
+        // @ts-ignore
+        chroma({ r: 128, g: 128, b: 128 }).hex();
+      }),
+
+      b.cycle(),
+      b.complete()
+    ),
+];
+
+type Verdict = { suite: string; speedup: number; floor: number; rival: string; passed: boolean };
+
+const format = (ops: number) => ops.toLocaleString("en-US");
+
+const verdictOf = (summary: Summary): Verdict => {
+  const colordResult = summary.results.find((result) => result.name === "colord");
+  if (!colordResult) throw new Error(`No "colord" case in the "${summary.name}" suite`);
+
+  const rivals = summary.results.filter((result) => result.name !== "colord");
+  const rival = rivals.reduce((best, result) => (result.ops > best.ops ? result : best));
+
+  const floor = MIN_SPEEDUP[summary.name];
+  if (floor === undefined) throw new Error(`No MIN_SPEEDUP entry for the "${summary.name}" suite`);
+
+  const speedup = colordResult.ops / rival.ops;
+  return { suite: summary.name, speedup, floor, rival: rival.name, passed: speedup >= floor };
+};
+
+const report = (summary: Summary, verdict: Verdict) => {
+  const colordOps = summary.results.filter((result) => result.name === "colord")[0].ops;
+  const sorted = [...summary.results].sort((a, b) => b.ops - a.ops);
+  const rows = sorted.map((result) => {
+    const isColord = result.name === "colord";
+    const name = isColord ? "**colord 👑**" : result.name;
+    const ops = isColord ? `**${format(result.ops)}**` : format(result.ops);
+    const relative = isColord ? "—" : `${(colordOps / result.ops).toFixed(2)}x slower`;
+    return `| ${name} | ${ops} | ±${result.margin.toFixed(2)}% | ${relative} |`;
+  });
+
+  return [
+    `### ${summary.name}`,
+    "",
+    "| Library | Operations/sec | Margin | vs colord |",
+    "| ------- | -------------- | ------ | --------- |",
+    ...rows,
+    "",
+    `${verdict.passed ? "✅" : "❌"} **${verdict.speedup.toFixed(2)}x** faster than the fastest ` +
+      `rival (${verdict.rival}); floor is **${verdict.floor.toFixed(2)}x**.`,
+    "",
+  ].join("\n");
+};
+
+const main = async () => {
+  const summaries: Summary[] = [];
+  for (const suite of suites) summaries.push(await suite());
+
+  const verdicts = summaries.map(verdictOf);
+  const markdown = summaries.map((summary, i) => report(summary, verdicts[i])).join("\n");
+
+  console.log(`\n${markdown}`);
+
+  if (process.env.GITHUB_STEP_SUMMARY) {
+    appendFileSync(process.env.GITHUB_STEP_SUMMARY, `${markdown}\n`);
+  }
+
+  const failed = verdicts.filter((verdict) => !verdict.passed);
+  if (failed.length > 0) {
+    for (const verdict of failed) {
+      console.error(
+        `Performance regression in "${verdict.suite}": ${verdict.speedup.toFixed(2)}x over ` +
+          `${verdict.rival}, expected at least ${verdict.floor.toFixed(2)}x.`
+      );
+    }
+    process.exitCode = 1;
+  }
+};
+
+main();

--- a/tests/benchmark.ts
+++ b/tests/benchmark.ts
@@ -1,6 +1,5 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 import b from "benny";
-import { Summary } from "benny/lib/internal/common-types";
 import { appendFileSync } from "fs";
 import { colord } from "../src";
 // @ts-ignore
@@ -11,6 +10,12 @@ import color from "color";
 import chroma from "chroma-js";
 // @ts-ignore
 import AcColor from "ac-colors";
+
+// benny only exposes its Summary type through `lib/internal`, which is not public API and
+// is free to move between versions. Reading it off `suite()` keeps us on the public
+// surface. (`Awaited` would say this in one line, but the repo is on TypeScript 4.2.)
+type Resolved<T> = T extends Promise<infer U> ? U : never;
+type Summary = Resolved<ReturnType<typeof b.suite>>;
 
 /**
  * How much faster colord must stay than its fastest rival in each suite.
@@ -127,7 +132,14 @@ const suites = [
     ),
 ];
 
-type Verdict = { suite: string; speedup: number; floor: number; rival: string; passed: boolean };
+type Verdict = {
+  suite: string;
+  colordOps: number;
+  speedup: number;
+  floor: number;
+  rival: string;
+  passed: boolean;
+};
 
 const format = (ops: number) => ops.toLocaleString("en-US");
 
@@ -142,19 +154,35 @@ const verdictOf = (summary: Summary): Verdict => {
   if (floor === undefined) throw new Error(`No MIN_SPEEDUP entry for the "${summary.name}" suite`);
 
   const speedup = colordResult.ops / rival.ops;
-  return { suite: summary.name, speedup, floor, rival: rival.name, passed: speedup >= floor };
+  return {
+    suite: summary.name,
+    colordOps: colordResult.ops,
+    speedup,
+    floor,
+    rival: rival.name,
+    passed: speedup >= floor,
+  };
 };
 
+// Both the column and the headline have to name the direction, not assume it: the run
+// that matters most is the one where a rival has overtaken colord.
+const relativeTo = (ratio: number) =>
+  ratio >= 1 ? `${ratio.toFixed(2)}x slower` : `${(1 / ratio).toFixed(2)}x faster`;
+
 const report = (summary: Summary, verdict: Verdict) => {
-  const colordOps = summary.results.filter((result) => result.name === "colord")[0].ops;
   const sorted = [...summary.results].sort((a, b) => b.ops - a.ops);
   const rows = sorted.map((result) => {
     const isColord = result.name === "colord";
     const name = isColord ? "**colord 👑**" : result.name;
     const ops = isColord ? `**${format(result.ops)}**` : format(result.ops);
-    const relative = isColord ? "—" : `${(colordOps / result.ops).toFixed(2)}x slower`;
+    const relative = isColord ? "—" : relativeTo(verdict.colordOps / result.ops);
     return `| ${name} | ${ops} | ±${result.margin.toFixed(2)}% | ${relative} |`;
   });
+
+  const headline =
+    verdict.speedup >= 1
+      ? `**${verdict.speedup.toFixed(2)}x** faster than the fastest rival (${verdict.rival})`
+      : `**${(1 / verdict.speedup).toFixed(2)}x** slower than ${verdict.rival}`;
 
   return [
     `### ${summary.name}`,
@@ -163,8 +191,7 @@ const report = (summary: Summary, verdict: Verdict) => {
     "| ------- | -------------- | ------ | --------- |",
     ...rows,
     "",
-    `${verdict.passed ? "✅" : "❌"} **${verdict.speedup.toFixed(2)}x** faster than the fastest ` +
-      `rival (${verdict.rival}); floor is **${verdict.floor.toFixed(2)}x**.`,
+    `${verdict.passed ? "✅" : "❌"} ${headline}; floor is **${verdict.floor.toFixed(2)}x**.`,
     "",
   ].join("\n");
 };
@@ -186,8 +213,9 @@ const main = async () => {
   if (failed.length > 0) {
     for (const verdict of failed) {
       console.error(
-        `Performance regression in "${verdict.suite}": ${verdict.speedup.toFixed(2)}x over ` +
-          `${verdict.rival}, expected at least ${verdict.floor.toFixed(2)}x.`
+        `Performance regression in "${verdict.suite}": colord runs at ` +
+          `${verdict.speedup.toFixed(2)}x the speed of ${verdict.rival}, ` +
+          `expected at least ${verdict.floor.toFixed(2)}x.`
       );
     }
     process.exitCode = 1;

--- a/tests/benchmark.ts
+++ b/tests/benchmark.ts
@@ -29,7 +29,7 @@ type Summary = Resolved<ReturnType<typeof b.suite>>;
  */
 const MIN_SPEEDUP: Record<string, number> = {
   "Parse HEX and convert to HSLA object/array": 2.2,
-  "Lighten, saturate, set alpha and convert to RGBA object": 2.0,
+  "Lighten, saturate, set alpha and convert to RGBA object": 1.9,
   "Parse RGBA object and convert to HEX string": 1.7,
 };
 


### PR DESCRIPTION
Runs `npm run benchmark` in CI, so it can serve as a perf regression check and as the place the README benchmark numbers come from.

## Why a ratio and not ops/sec

Absolute ops/sec on shared runners swing ±10–30% between runs, so comparing today's run against yesterday's is meaningless. Instead the check watches how much faster colord is than its fastest rival in each suite — every library is measured on the same machine in the same run, which cancels most of the noise out.

That ratio is much steadier, but it is not machine-independent either. The README table used to imply 4.74x over `color` on the parse suite; the pinned runner gives 3.83x. So the runner image (`ubuntu-24.04`, not `latest`) and the Node major are pinned, and the floors in `MIN_SPEEDUP` only mean anything against that fixed environment. They are set ~20% below the first real CI run:

| Suite | Measured | Floor |
| ----- | -------- | ----- |
| Parse HEX → HSLA | 2.81x over tinycolor2 | 2.20x |
| Lighten/saturate/alpha → RGBA | 2.49x over color | 2.00x |
| RGBA object → HEX string | 2.16x over tinycolor2 | 1.70x |

## Three suites instead of one

`tests/benchmark.ts` only measured hex parsing. Parsing, manipulation and serialization are separate code paths, and a regression in colord's manipulation math would have gone completely unseen. Added:

- **Parse HEX → HSLA** — unchanged, still the source of the README ops/sec figure
- **Lighten → saturate → alpha → RGBA** — no `ac-colors`, it ships no manipulation methods at all
- **RGBA object → HEX string**

The manipulation suite compares operations that are not strictly equivalent (tinycolor2 takes percents, chroma-js brightens in Lab). That is fine for regression detection, where the rivals are just a denominator, but it is why the README figure stays tied to the parse suite.

## README

Numbers refreshed from the CI run. The **Fast** bullet goes from "4x+ faster than color" to "4x faster" — 3.83x rounds to 4x but is not more than 4x. The **Small** bullet keeps its "4x+ lighter" (7.52 kB / 1.71 kB = 4.40x).

## Other bits

- Benchmark lives in its own workflow, not in the `node.yml` matrix — no point running 85 seconds of it three times per push.
- The job writes a markdown table to the job summary, ready to copy into the README.
- `npm run benchmark` now cleans up `./bench` and propagates the exit code even when the run fails; before, a non-zero exit left the temp directory behind.
- `npm ci` rather than `npm install`, since the rival libraries are the denominator of every measurement.