### PR TITLE
chore: prepare the 2.9.7 release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "colord",
-  "version": "2.9.6",
+  "version": "2.9.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "colord",
-      "version": "2.9.6",
+      "version": "2.9.7",
       "license": "MIT",
       "devDependencies": {
         "@size-limit/preset-small-lib": "^11.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "colord",
-  "version": "2.9.6",
+  "version": "2.9.7",
   "description": "👑 A tiny yet powerful tool for high-performance color manipulations and conversions",
   "keywords": [
     "color",


### PR DESCRIPTION
Bumps the version to 2.9.7. The CHANGELOG entry landed with #153.

### 2.9.7

- Make HEX parsing and serialization more than 2x faster

## Verified

`npm test` (98 passed), `npm run check-types`, `eslint`, and `size-limit` all pass. `npm run check-release` packages `colord@2.9.7` cleanly — 67 files, 36.5 kB packed, 124.8 kB unpacked — and the shipped `dist/index.mjs` carries the change (no `parseInt` left in the bundle).

Patch release, so no git tag and no GitHub Release per the repo's convention.
