### PR TITLE
docs: document the modern whitespace CSS syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,8 +90,8 @@ colord("hsl(0, 50%, 50%)").darken(0.25).toHex(); // "#602020"
 ## Supported Color Models
 
 - Hexadecimal strings (including 3, 4 and 8 digit notations)
-- RGB strings and objects
-- HSL strings and objects
+- RGB strings (comma and whitespace syntax) and objects
+- HSL strings (comma and whitespace syntax) and objects
 - HSV objects
 - Color names ([via plugin](#plugins))
 - HWB objects and strings ([via plugin](#plugins))
@@ -120,11 +120,17 @@ colord("#ffffff");
 colord("#ffffffff");
 colord("rgb(255, 255, 255)");
 colord("rgba(255, 255, 255, 0.5)");
-colord("rgba(100% 100% 100% / 50%)");
 colord("hsl(90, 100%, 100%)");
 colord("hsla(90, 100%, 100%, 0.5)");
-colord("hsla(90deg 100% 100% / 50%)");
 colord("tomato"); // requires "names" plugin
+
+// Modern whitespace syntax
+colord("rgb(255 255 255)");
+colord("rgb(255 255 255 / 0.5)");
+colord("rgb(100% 100% 100% / 50%)");
+colord("hsl(90 100% 100%)");
+colord("hsl(90deg 100% 100% / 50%)");
+colord("hsl(0.25turn 100% 100% / 50%)");
 
 // Object input examples
 colord({ r: 255, g: 255, b: 255 });
@@ -150,6 +156,7 @@ import { getFormat } from "colord";
 getFormat("#aabbcc"); // "hex"
 getFormat({ r: 13, g: 237, b: 162, a: 0.5 }); // "rgb"
 getFormat("hsl(180deg, 50%, 50%)"); // "hsl"
+getFormat("hsl(180deg 50% 50% / 50%)"); // "hsl"
 getFormat("WUT?"); // undefined
 ```
 


### PR DESCRIPTION
Documentation only — no source changes.

## Why

[#99](https://github.com/omgovich/colord/issues/99) asks whether `hsl(0 0% 0% / 0.5)` can be supported. It already is — whitespace syntax has been parsed since **v1.3.1** (May 2021). The README just barely showed it: of ~20 `rgb()`/`hsl()` examples, only two used it, and both spelled it with the legacy function names (`rgba(100% 100% 100% / 50%)`, `hsla(90deg 100% 100% / 50%)`), so anyone scanning for `hsl(… … … / …)` concluded it was missing.

## What changed

- **Supported Color Models** — RGB/HSL bullets mention both syntaxes.
- **`colord(input)`** — a block of modern examples (numbers, percentages, `/` alpha, `deg` and `turn` hue units). The two odd `rgba(… … … / …)` / `hsla(… … … / …)` lines are replaced by their `rgb()` / `hsl()` equivalents.
- **`getFormat`** — one modern example.

## How to review

Read the rendered diff — three spots in `README.md`, all examples.

Every new example was checked against `src/` before committing (temporary test, not part of the diff): all six input strings parse to the expected color, and `getFormat("hsl(180deg 50% 50% / 50%)")` returns `"hsl"`. `npm test` still passes, 813 tests unchanged.

`README.md` is not covered by `npm run lint` (`src/**/*.ts` only) and was already not Prettier-clean before this change, so I did not reformat it — that would have buried the diff.

## Out of scope

Modern-syntax **output** (`toHslString()` → `hsl(0 100% 50% / 0.5)`), which is what #99 turned into after it was reopened. That changes behavior for every dependent, so it needs its own PR and a decision about opt-in vs. default. #99 should stay open for it.
